### PR TITLE
Integrate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ default = []
 proptests = ["quickcheck"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.127", features = ["derive"] }
 nix = "0.22.0"
-anyhow = "1.0"
-serde_json = "1.0"
+anyhow = "1.0.42"
+serde_json = "1.0.66"
 # Waiting for new caps release, replace git with version on release
 caps = { git = "https://github.com/lucab/caps-rs", rev = "cb54844", features = ["serde_support"] }
-quickcheck = { version = "1", optional = true }
-tempfile = "3"
+quickcheck = { version = "1.0.3", optional = true }
+tempfile = "3.2.0"


### PR DESCRIPTION
This adds a dependabot configuration to automatically bump the
dependencies of the crate. Everything in `Cargo.toml` got an upgrade,
too.
