### PR TITLE
Add gh-pages docs publish step

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,32 @@
+name: gh-pages
+on:
+  push:
+    branches:
+      - main
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate lockfile
+        run: cargo generate-lockfile
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Documentation
+        run: cargo doc
+      - name: Deploy Documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_branch: gh-pages
+          publish_dir: ./target/doc
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # oci-spec-rs
+
+[![docs](https://img.shields.io/badge/docs-master-blue.svg)](https://containers.github.io/oci-spec-rs/oci_spec)


### PR DESCRIPTION
This adds a documentation publishing step as GitHub pages workflow.

Refers to https://github.com/containers/oci-spec-rs/issues/3