### PR TITLE
Fix docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # oci-spec-rs
 
-[![docs](https://img.shields.io/badge/docs-master-blue.svg)](https://containers.github.io/oci-spec-rs/oci_spec)
+[![docs](https://img.shields.io/badge/docs-master-blue.svg)](https://containers.github.io/oci-spec-rs/oci_spec/index.html)


### PR DESCRIPTION
Fixing the URL of the badge to point to the `index.html` directly.
