### PR TITLE
Fix codecov generation

### DIFF
--- a/.github/grcov.yml
+++ b/.github/grcov.yml
@@ -1,0 +1,7 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+filter: covered
+output-type: lcov
+output-path: ./lcov.info
+prefix-dir: /home/user/build/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,5 +91,7 @@ jobs:
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
       - name: Coverage
         uses: actions-rs/grcov@v0.1
+        with:
+          config: .github/grcov.yml
       - name: Upload Results
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
Code coverage reports were not uploaded. We now switch to the latest
version to fix that issue.
