### PR TITLE
Remove nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ builder = ["derive_builder"]
 
 [dependencies]
 serde = { version = "1.0.127", features = ["derive"] }
-nix = "0.22.0"
 anyhow = "1.0.42"
 serde_json = "1.0.66"
 # Waiting for new caps release, replace git with version on release

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use nix::sys::stat::SFlag;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom, path::PathBuf};
 
@@ -170,15 +169,6 @@ impl Default for LinuxDeviceType {
 }
 
 impl LinuxDeviceType {
-    pub fn to_sflag(&self) -> Result<SFlag> {
-        Ok(match self {
-            Self::B => SFlag::S_IFBLK,
-            Self::C | LinuxDeviceType::U => SFlag::S_IFCHR,
-            Self::P => SFlag::S_IFIFO,
-            Self::A => bail!("type a is not allowed for linux device"),
-        })
-    }
-
     pub fn as_str(&self) -> &str {
         match self {
             Self::B => "b",


### PR DESCRIPTION
Now that the oci spec is decoupled from youki, we should not expose nix types as part of the api.