### PR TITLE
Add `builder` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo build
+      - run: cargo build --all-features
 
   doc:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo doc --no-deps
+      - run: cargo doc --all-features --no-deps
 
   lint-clippy:
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
       - name: Clippy Lint
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --all --all-features -- -D warnings
 
   lint-rustfmt:
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --no-fail-fast
+          args: --lib --all-features --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [features]
 default = []
 proptests = ["quickcheck"]
+builder = ["derive_builder"]
 
 [dependencies]
 serde = { version = "1.0.127", features = ["derive"] }
@@ -16,3 +17,4 @@ serde_json = "1.0.66"
 caps = { git = "https://github.com/lucab/caps-rs", rev = "cb54844", features = ["serde_support"] }
 quickcheck = { version = "1.0.3", optional = true }
 tempfile = "3.2.0"
+derive_builder = { version = "0.10.2", optional = true }

--- a/src/runtime/hooks.rs
+++ b/src/runtime/hooks.rs
@@ -3,6 +3,11 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Hooks specifies a command that is run in the container at a particular event in the lifecycle
 /// (setup and teardown) of a container.
 pub struct Hooks {
@@ -50,6 +55,11 @@ pub struct Hooks {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Hook specifies a command that is run at a particular event in the lifecycle of a container.
 pub struct Hook {
     /// Path to the binary to be executed. Following similar semantics to [IEEE Std 1003.1-2008

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -5,6 +5,11 @@ use std::{collections::HashMap, convert::TryFrom, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Linux contains platform-specific configuration for Linux based containers.
 pub struct Linux {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -116,8 +121,13 @@ impl Default for Linux {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxIDMapping specifies UID/GID mappings.
 pub struct LinuxIdMapping {
     #[serde(default, rename = "hostID")]
@@ -181,6 +191,11 @@ impl LinuxDeviceType {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Represents a device rule for the devices specified to the device controller
 pub struct LinuxDeviceCgroup {
     #[serde(default)]
@@ -223,8 +238,13 @@ impl ToString for LinuxDeviceCgroup {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxMemory for Linux cgroup 'memory' resource management.
 pub struct LinuxMemory {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -260,8 +280,13 @@ pub struct LinuxMemory {
     pub use_hierarchy: Option<bool>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxCPU for Linux cgroup 'cpu' resource management.
 pub struct LinuxCpu {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -293,7 +318,12 @@ pub struct LinuxCpu {
     pub mems: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3).
 pub struct LinuxPids {
     #[serde(default)]
@@ -301,8 +331,13 @@ pub struct LinuxPids {
     pub limit: i64,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxWeightDevice struct holds a `major:minor weight` pair for weightDevice.
 pub struct LinuxWeightDevice {
     #[serde(default)]
@@ -323,7 +358,12 @@ pub struct LinuxWeightDevice {
     pub leaf_weight: Option<u16>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxThrottleDevice struct holds a `major:minor rate_per_second` pair.
 pub struct LinuxThrottleDevice {
     #[serde(default)]
@@ -339,8 +379,13 @@ pub struct LinuxThrottleDevice {
     pub rate: u64,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxBlockIO for Linux cgroup 'blkio' resource management.
 pub struct LinuxBlockIo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -373,8 +418,13 @@ pub struct LinuxBlockIo {
     pub throttle_write_iops_device: Option<Vec<LinuxThrottleDevice>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxHugepageLimit structure corresponds to limiting kernel hugepages.
 pub struct LinuxHugepageLimit {
     #[serde(default)]
@@ -387,7 +437,12 @@ pub struct LinuxHugepageLimit {
     pub limit: i64,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxInterfacePriority for network interfaces.
 pub struct LinuxInterfacePriority {
     #[serde(default)]
@@ -405,7 +460,12 @@ impl ToString for LinuxInterfacePriority {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxNetwork identification and priority configuration.
 pub struct LinuxNetwork {
     #[serde(skip_serializing_if = "Option::is_none", rename = "classID")]
@@ -419,6 +479,11 @@ pub struct LinuxNetwork {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Resource constraints for container
 pub struct LinuxResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -473,6 +538,11 @@ pub struct LinuxResources {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11).
 pub struct LinuxRdma {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -526,7 +596,18 @@ impl TryFrom<&str> for LinuxNamespaceType {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+impl Default for LinuxNamespaceType {
+    fn default() -> Self {
+        Self::Pid
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxNamespace is the configuration for a Linux namespace.
 pub struct LinuxNamespace {
     #[serde(rename = "type")]
@@ -565,8 +646,13 @@ pub fn get_default_namespaces() -> Vec<LinuxNamespace> {
     ]
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxDevice represents the mknod information for a Linux special device file.
 pub struct LinuxDevice {
     #[serde(default)]
@@ -610,8 +696,13 @@ impl From<&LinuxDevice> for LinuxDeviceCgroup {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxSeccomp represents syscall restrictions.
 pub struct LinuxSeccomp {
     pub default_action: LinuxSeccompAction,
@@ -635,6 +726,12 @@ pub enum LinuxSeccompAction {
     ScmpActErrno = 0x00050001,
     ScmpActTrace = 0x7ff00001,
     ScmpActAllow = 0x7fff0000,
+}
+
+impl Default for LinuxSeccompAction {
+    fn default() -> Self {
+        Self::ScmpActAllow
+    }
 }
 
 #[allow(clippy::enum_clike_unportable_variant)]
@@ -673,7 +770,18 @@ pub enum LinuxSeccompOperator {
     ScmpCmpMaskedEq = 7,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+impl Default for LinuxSeccompOperator {
+    fn default() -> Self {
+        Self::ScmpCmpEq
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxSyscall is used to match a syscall in seccomp.
 pub struct LinuxSyscall {
     pub names: Vec<String>,
@@ -687,8 +795,13 @@ pub struct LinuxSyscall {
     pub args: Option<Vec<LinuxSeccompArg>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxSeccompArg used for matching specific syscall arguments in seccomp.
 pub struct LinuxSeccompArg {
     pub index: usize,
@@ -738,8 +851,13 @@ pub enum FreezerState {
     Thawed,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxIntelRdt has container runtime resource constraints for Intel RDT CAT and MBA features
 /// which introduced in Linux 4.10 and 4.12 kernel.
 pub struct LinuxIntelRdt {
@@ -760,7 +878,12 @@ pub struct LinuxIntelRdt {
     pub mem_bw_schema: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxPersonality represents the Linux personality syscall input.
 pub struct LinuxPersonality {
     /// Domain for the personality.
@@ -781,6 +904,12 @@ pub enum LinuxPersonalityDomain {
     #[serde(rename = "LINUX32")]
     /// PerLinux32 sets personality to 32 bit.
     PerLinux32,
+}
+
+impl Default for LinuxPersonalityDomain {
+    fn default() -> Self {
+        Self::PerLinux
+    }
 }
 
 #[cfg(feature = "proptests")]

--- a/src/runtime/miscellaneous.rs
+++ b/src/runtime/miscellaneous.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Root contains information about the container's root filesystem on the host.
 pub struct Root {
     /// Path is the absolute path to the container's root filesystem.
@@ -24,7 +29,12 @@ impl Default for Root {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Mount specifies a mount for a container.
 pub struct Mount {
     /// Destination is the absolute path where the mount will be placed in the container.

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -4,6 +4,11 @@ use serde::{Deserialize, Serialize};
 /// Process contains information to start a specific application inside the container.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 pub struct Process {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Terminal creates an interactive terminal for the container.
@@ -101,6 +106,11 @@ impl Default for Process {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Box specifies dimensions of a rectangle. Used for specifying the size of a console.
 pub struct Box {
     #[serde(default)]
@@ -166,7 +176,18 @@ pub enum LinuxRlimitType {
     RlimitRttime,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+impl Default for LinuxRlimitType {
+    fn default() -> Self {
+        Self::RlimitCpu
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// RLimit types and restrictions.
 pub struct LinuxRlimit {
     #[serde(rename = "type")]
@@ -184,6 +205,11 @@ pub struct LinuxRlimit {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// User id (uid) and group id (gid) tracks file permssions.
 pub struct User {
     #[serde(default)]
@@ -204,6 +230,11 @@ pub struct User {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
 /// http://man7.org/linux/man-pages/man7/capabilities.7.html
 pub struct LinuxCapabilities {

--- a/src/runtime/solaris.rs
+++ b/src/runtime/solaris.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Solaris contains platform-specific configuration for Solaris application containers.
 pub struct Solaris {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -31,6 +36,11 @@ pub struct Solaris {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// SolarisAnet provides the specification for automatic creation of network resources for this
 /// container.
 pub struct SolarisAnet {
@@ -64,6 +74,11 @@ pub struct SolarisAnet {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// SolarisCappedCPU allows users to set limit on the amount of CPU time that can be used by
 /// container.
 pub struct SolarisCappedCPU {
@@ -72,6 +87,11 @@ pub struct SolarisCappedCPU {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// SolarisCappedMemory allows users to set the physical and swap caps on the memory that can be
 /// used by this container.
 pub struct SolarisCappedMemory {

--- a/src/runtime/vm.rs
+++ b/src/runtime/vm.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// VM contains information for virtual-machine-based containers.
 pub struct VM {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17,6 +22,11 @@ pub struct VM {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// VMHypervisor contains information about the hypervisor to use for a virtual machine.
 pub struct VMHypervisor {
     /// Path is the host path to the hypervisor used to manage the virtual machine.
@@ -28,6 +38,11 @@ pub struct VMHypervisor {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// VMKernel contains information about the kernel to use for a virtual machine.
 pub struct VMKernel {
     /// Path is the host path to the kernel used to boot the virtual machine.
@@ -43,6 +58,11 @@ pub struct VMKernel {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// VMImage contains information about the virtual machine root image.
 pub struct VMImage {
     /// Path is the host path to the root image that the VM kernel would boot into.

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -3,6 +3,11 @@ use std::collections::HashMap;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// Windows defines the runtime configuration for Windows based containers, including Hyper-V
 /// containers.
 pub struct Windows {
@@ -43,6 +48,11 @@ pub struct Windows {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// WindowsDevice represents information about a host device to be mapped into the container.
 pub struct WindowsDevice {
     /// Device identifier: interface class GUID, etc..
@@ -53,6 +63,11 @@ pub struct WindowsDevice {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 pub struct WindowsResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Memory restriction configuration.
@@ -68,6 +83,11 @@ pub struct WindowsResources {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// WindowsMemoryResources contains memory resource management settings.
 pub struct WindowsMemoryResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -76,6 +96,11 @@ pub struct WindowsMemoryResources {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// WindowsCPUResources contains CPU resource management settings.
 pub struct WindowsCPUResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -94,6 +119,11 @@ pub struct WindowsCPUResources {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// WindowsStorageResources contains storage resource management settings.
 pub struct WindowsStorageResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -111,6 +141,11 @@ pub struct WindowsStorageResources {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.
 pub struct WindowsHyperV {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -120,6 +155,11 @@ pub struct WindowsHyperV {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(default, pattern = "owned", setter(into, strip_option))
+)]
 /// WindowsNetwork contains network settings for Windows containers.
 pub struct WindowsNetwork {
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
The `builder` feature can be used to enable the builder pattern to
generate the OCI spec.
