### PR TITLE
Move tempfile to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ serde_json = "1.0.66"
 # Waiting for new caps release, replace git with version on release
 caps = { git = "https://github.com/lucab/caps-rs", rev = "cb54844", features = ["serde_support"] }
 quickcheck = { version = "1.0.3", optional = true }
-tempfile = "3.2.0"
 derive_builder = { version = "0.10.2", optional = true }
+
+[dev-dependencies]
+tempfile = "3.2.0"


### PR DESCRIPTION
We do not need the dependency in the library, but in the tests.