### PR TITLE
Rename the crate to oci-spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "oci_spec"
+name = "oci-spec"
 version = "0.1.0"
 edition = "2018"
 


### PR DESCRIPTION
Referring to the discussion in https://github.com/containers/oci-spec-rs/issues/3#issuecomment-899509402

Does it make any difference? I think the crate will be automatically renamed to `oci_spec`. Would we prefer `oci_spec` in `Cargo.toml` over `oci-spec`?