### PR TITLE
Add crates.io/docs.rs badges and meta to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 authors = [
     "Furisto",
     "Sascha Grunert <sgrunert@redhat.com>",
-    "Toru Komatsu <k0ma@utam0k.jp",
+    "Toru Komatsu <k0ma@utam0k.jp>",
 ]
 description = "Open Container Initiative Specifictions in Rust"
 documentation = "https://docs.rs/oci-spec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,20 @@
 [package]
 name = "oci-spec"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2018"
+authors = [
+    "Furisto",
+    "Sascha Grunert <sgrunert@redhat.com>",
+    "Toru Komatsu <k0ma@utam0k.jp",
+]
+description = "Open Container Initiative Specifictions in Rust"
+documentation = "https://docs.rs/oci-spec"
+readme = "README.md"
+homepage = "https://github.com/containers/oci-spec-rs"
+repository = "https://github.com/containers/oci-spec-rs"
+license = "Apache-2.0"
+keywords = ["oci", "spec", "container", "runtime", "image"]
+categories = ["api-bindings"]
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # oci-spec-rs
 
 [![ci](https://github.com/containers/oci-spec-rs/workflows/ci/badge.svg)](https://github.com/containers/oci-spec-rs/actions)
+[![gh-pages](https://github.com/containers/oci-spec-rs/workflows/gh-pages/badge.svg)](https://github.com/containers/oci-spec-rs/actions)
+[![crates.io](https://img.shields.io/crates/v/oci-spec.svg)](https://crates.io/crates/oci-spec)
 [![codecov](https://codecov.io/gh/containers/oci-spec-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/containers/oci-spec-rs)
 [![docs](https://img.shields.io/badge/docs-main-blue.svg)](https://containers.github.io/oci-spec-rs/oci_spec/index.html)
-
+[![docs.rs](https://docs.rs/oci-spec/badge.svg)](https://docs.rs/oci-spec)


### PR DESCRIPTION
We're probably ready for a 0.3.0 release, right? This way we do not have to yank the existing versions of `oci-spec` on crates.io.

Edit: I think we cannot release with this:
https://github.com/containers/oci-spec-rs/blob/188d863771074bc9f8995dd5947288e4bd6407ea/Cargo.toml#L15-L16