### PR TITLE
Add docs to Spec API methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #[macro_use]
 mod macros;
 
-/// [OCI runtime spec](https://github.com/opencontainers/runtime-spec) types and definitions.
 pub mod runtime;


### PR DESCRIPTION
This adds doc comments to the existing `Spec` API methods. We now also
use `path.display()` to construct errors without the debug formatter.
