### PR TITLE
Make capabilities a `HashSet`

### DIFF
--- a/src/runtime/capability.rs
+++ b/src/runtime/capability.rs
@@ -2,8 +2,12 @@ use serde::{
     de::{Deserializer, Error},
     Deserialize, Serialize,
 };
+use std::collections::HashSet;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+/// Capabilities is a unique set of Capability values.
+pub type Capabilities = HashSet<Capability>;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
 /// All available capabilities.
 ///
 /// For the purpose of performing permission checks, traditional UNIX
@@ -588,6 +592,22 @@ mod tests {
             let res: Capability = serde_json::from_str(&format!("\"{}\"", case))?;
             assert_eq!(Capability::Syslog, res);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn capabilities() -> Result<()> {
+        let res: Capabilities = serde_json::from_str(
+            r#"[
+                "syslog",
+                "SYSLOG",
+                "chown",
+                "cap_chown"
+            ]"#,
+        )?;
+        assert_eq!(res.len(), 2);
+        assert!(res.contains(&Capability::Syslog));
+        assert!(res.contains(&Capability::Chown));
         Ok(())
     }
 }

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -1,7 +1,6 @@
-use std::path::PathBuf;
-
-use crate::runtime::Capability;
+use crate::runtime::{Capabilities, Capability};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 make_pub!(
     /// Process contains information to start a specific application inside the
@@ -282,23 +281,23 @@ make_pub!(
     struct LinuxCapabilities {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         /// Bounding is the set of capabilities checked by the kernel.
-        bounding: Option<Vec<Capability>>,
+        bounding: Option<Capabilities>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
         /// Effective is the set of capabilities checked by the kernel.
-        effective: Option<Vec<Capability>>,
+        effective: Option<Capabilities>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
         /// Inheritable is the capabilities preserved across execve.
-        inheritable: Option<Vec<Capability>>,
+        inheritable: Option<Capabilities>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
         /// Permitted is the limiting superset for effective capabilities.
-        permitted: Option<Vec<Capability>>,
+        permitted: Option<Capabilities>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
         /// Ambient is the ambient set of capabilities that are kept.
-        ambient: Option<Vec<Capability>>,
+        ambient: Option<Capabilities>,
     }
 );
 
@@ -311,7 +310,9 @@ impl Default for LinuxCapabilities {
         let audit_write = Capability::AuditWrite;
         let cap_kill = Capability::Kill;
         let net_bind = Capability::NetBindService;
-        let default_vec = vec![audit_write, cap_kill, net_bind];
+        let default_vec = vec![audit_write, cap_kill, net_bind]
+            .into_iter()
+            .collect::<Capabilities>();
         LinuxCapabilities {
             bounding: default_vec.clone().into(),
             effective: default_vec.clone().into(),


### PR DESCRIPTION
We now use a new type for the capabilities to automatically remove
duplications on deserialization.
