### PR TITLE
Add Hash derive to LinuxNamespaceType

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -685,7 +685,7 @@ make_pub!(
     }
 );
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, Hash)]
 #[serde(rename_all = "snake_case")]
 /// Available Linux namespaces.
 pub enum LinuxNamespaceType {


### PR DESCRIPTION
Need this to use LinuxNamespaceType as keys to hash map. In current
implementation, we used CloneFlags as a substitutude, but that's not
ideal.