### PR TITLE
Add version to each spec

### DIFF
--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -14,7 +14,9 @@
 mod error;
 mod repository;
 mod tag;
+mod version;
 
 pub use error::*;
 pub use repository::*;
 pub use tag::*;
+pub use version::*;

--- a/src/distribution/version.rs
+++ b/src/distribution/version.rs
@@ -1,0 +1,29 @@
+/// API incompatible changes.
+pub const VERSION_MAJOR: u32 = 1;
+
+/// Changing functionality in a backwards-compatible manner
+pub const VERSION_MINOR: u32 = 0;
+
+/// Backwards-compatible bug fixes.
+pub const VERSION_PATCH: u32 = 0;
+
+/// Indicates development branch. Releases will be empty string.
+pub const VERSION_DEV: &str = "-dev";
+
+/// Retrieve the version as string representation.
+pub fn version() -> String {
+    format!(
+        "{}.{}.{}{}",
+        VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_DEV
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_test() {
+        assert_eq!(version(), "1.0.0-dev".to_string())
+    }
+}

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -5,6 +5,7 @@ mod config;
 mod descriptor;
 mod index;
 mod manifest;
+mod version;
 
 use std::fmt::Display;
 
@@ -15,6 +16,7 @@ pub use config::*;
 pub use descriptor::*;
 pub use index::*;
 pub use manifest::*;
+pub use version::*;
 
 /// Media types used by OCI image format spec. Values MUST comply with RFC 6838,
 /// including the naming requirements in its section 4.2.

--- a/src/image/version.rs
+++ b/src/image/version.rs
@@ -1,0 +1,29 @@
+/// API incompatible changes.
+pub const VERSION_MAJOR: u32 = 1;
+
+/// Changing functionality in a backwards-compatible manner
+pub const VERSION_MINOR: u32 = 0;
+
+/// Backwards-compatible bug fixes.
+pub const VERSION_PATCH: u32 = 1;
+
+/// Indicates development branch. Releases will be empty string.
+pub const VERSION_DEV: &str = "-dev";
+
+/// Retrieve the version as string representation.
+pub fn version() -> String {
+    format!(
+        "{}.{}.{}{}",
+        VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_DEV
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_test() {
+        assert_eq!(version(), "1.0.1-dev".to_string())
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,6 +16,7 @@ mod miscellaneous;
 mod process;
 mod solaris;
 mod test;
+mod version;
 mod vm;
 mod windows;
 
@@ -26,6 +27,7 @@ pub use linux::*;
 pub use miscellaneous::*;
 pub use process::*;
 pub use solaris::*;
+pub use version::*;
 pub use vm::*;
 pub use windows::*;
 

--- a/src/runtime/version.rs
+++ b/src/runtime/version.rs
@@ -1,0 +1,29 @@
+/// API incompatible changes.
+pub const VERSION_MAJOR: u32 = 1;
+
+/// Changing functionality in a backwards-compatible manner
+pub const VERSION_MINOR: u32 = 0;
+
+/// Backwards-compatible bug fixes.
+pub const VERSION_PATCH: u32 = 2;
+
+/// Indicates development branch. Releases will be empty string.
+pub const VERSION_DEV: &str = "-dev";
+
+/// Retrieve the version as string representation.
+pub fn version() -> String {
+    format!(
+        "{}.{}.{}{}",
+        VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_DEV
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_test() {
+        assert_eq!(version(), "1.0.2-dev".to_string())
+    }
+}


### PR DESCRIPTION
We now add the same consts to the different specs like in the golang
version. We also add the `version()` function to return a string
representation.