### PR TITLE
Add serde default for exposed ports

### DIFF
--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -258,6 +258,7 @@ make_pub!(
         /// A set of directories describing where the process is
         /// likely to write data specific to a container instance.
         #[serde(
+            default,
             skip_serializing_if = "Option::is_none",
             deserialize_with = "deserialize_as_vec",
             serialize_with = "serialize_as_map"

--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -231,6 +231,7 @@ make_pub!(
         /// These values act as defaults and are merged with any
         /// specified when creating a container.
         #[serde(
+            default,
             skip_serializing_if = "Option::is_none",
             deserialize_with = "deserialize_as_vec",
             serialize_with = "serialize_as_map"


### PR DESCRIPTION
When using `deserialize_with`, `Option` no longer tells deserializer that field might not exist.
Therefore in order to correctly deserialize `Config` without `exposed_ports` field, we need to add serde default for this field manually.

This should fix #50.