### PR TITLE
image: Add Descriptor::new()

### DIFF
--- a/src/image/descriptor.rs
+++ b/src/image/descriptor.rs
@@ -126,3 +126,17 @@ impl Default for Platform {
         }
     }
 }
+
+impl Descriptor {
+    /// Construct a new descriptor with the required fields.
+    pub fn new(media_type: MediaType, size: i64, digest: impl Into<String>) -> Self {
+        Self {
+            media_type,
+            size,
+            digest: digest.into(),
+            urls: Default::default(),
+            annotations: Default::default(),
+            platform: Default::default(),
+        }
+    }
+}

--- a/src/image/index.rs
+++ b/src/image/index.rs
@@ -210,20 +210,20 @@ mod tests {
 
     #[cfg(not(feature = "builder"))]
     fn create_index() -> ImageIndex {
-        let ppc_manifest = Descriptor {
-            media_type: MediaType::ImageManifest,
-            digest: "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"
-                .to_owned(),
-            size: 7143,
-            urls: None,
-            annotations: None,
-            platform: Some(Platform {
+        let ppc_manifest = {
+            let mut r = Descriptor::new(
+                MediaType::ImageManifest,
+                7143,
+                "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+            );
+            r.platform = Some(Platform {
                 architecture: "ppc64le".to_owned(),
                 os: "linux".to_owned(),
                 os_version: None,
                 os_features: None,
                 variant: None,
-            }),
+            });
+            r
         };
 
         let amd64_manifest = Descriptor {


### PR DESCRIPTION
Since IMO it's going to be very common to only use
the required fields, add a convenient constructor to do so.

Part of porting https://github.com/ostreedev/ostree-rs-ext
to this library.