### PR TITLE
Add a const SCHEMA_VERSION

### DIFF
--- a/src/image/index.rs
+++ b/src/image/index.rs
@@ -7,6 +7,9 @@ use std::{
     path::Path,
 };
 
+/// The expected schema version; equals 2 for compatibility with older versions of Docker.
+pub const SCHEMA_VERSION: u32 = 2;
+
 make_pub!(
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -151,7 +154,7 @@ impl ImageIndex {
 impl Default for ImageIndex {
     fn default() -> Self {
         Self {
-            schema_version: 2,
+            schema_version: SCHEMA_VERSION,
             media_type: Default::default(),
             manifests: Default::default(),
             annotations: Default::default(),
@@ -200,7 +203,7 @@ mod tests {
             .expect("build amd64 manifest descriptor");
 
         let index = ImageIndexBuilder::default()
-            .schema_version(2 as u32)
+            .schema_version(SCHEMA_VERSION)
             .manifests(vec![ppc_manifest, amd64_manifest])
             .build()
             .expect("build image index");
@@ -243,7 +246,7 @@ mod tests {
         };
 
         let index = ImageIndex {
-            schema_version: 2,
+            schema_version: SCHEMA_VERSION,
             media_type: None,
             manifests: vec![ppc_manifest, amd64_manifest],
             annotations: None,

--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -178,6 +178,8 @@ mod tests {
 
     #[cfg(feature = "builder")]
     fn create_manifest() -> ImageManifest {
+        use crate::image::SCHEMA_VERSION;
+
         let config = DescriptorBuilder::default()
             .media_type(MediaType::ImageConfig)
             .size(7023)
@@ -211,7 +213,7 @@ mod tests {
         .collect();
 
         let manifest = ImageManifestBuilder::default()
-            .schema_version(2 as u32)
+            .schema_version(SCHEMA_VERSION)
             .config(config)
             .layers(layers)
             .build()
@@ -222,6 +224,8 @@ mod tests {
 
     #[cfg(not(feature = "builder"))]
     fn create_manifest() -> ImageManifest {
+        use crate::image::SCHEMA_VERSION;
+
         let config = Descriptor {
             media_type: MediaType::ImageConfig,
             size: 7023,
@@ -263,7 +267,7 @@ mod tests {
         ];
 
         let manifest = ImageManifest {
-            schema_version: 2,
+            schema_version: SCHEMA_VERSION,
             media_type: None,
             config,
             layers,


### PR DESCRIPTION
It feels nicer than having `2` scattered about.