### PR TITLE
Use `..Default::default()` where possible

### DIFF
--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -182,16 +182,9 @@ impl ImageConfiguration {
 impl Default for ImageConfiguration {
     fn default() -> Self {
         Self {
-            created: Default::default(),
-            author: Default::default(),
             architecture: "amd64".to_owned(),
             os: "linux".to_owned(),
-            os_version: Default::default(),
-            os_features: Default::default(),
-            variant: Default::default(),
-            config: Default::default(),
-            rootfs: Default::default(),
-            history: Default::default(),
+            ..Default::default()
         }
     }
 }
@@ -365,7 +358,7 @@ impl Default for RootFs {
     fn default() -> Self {
         Self {
             typ: "layers".to_owned(),
-            diff_ids: Default::default(),
+            ..Default::default()
         }
     }
 }

--- a/src/image/descriptor.rs
+++ b/src/image/descriptor.rs
@@ -120,9 +120,7 @@ impl Default for Platform {
         Self {
             architecture: "amd64".to_owned(),
             os: "linux".to_owned(),
-            os_version: Default::default(),
-            os_features: Default::default(),
-            variant: Default::default(),
+            ..Default::default()
         }
     }
 }

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -94,44 +94,19 @@ make_pub!(
 impl Default for Linux {
     fn default() -> Self {
         Linux {
-            // Creates empty Vec
-            uid_mappings: Default::default(),
-            // Creates empty Vec
-            gid_mappings: Default::default(),
-            // Empty sysctl Hashmap
-            sysctl: Default::default(),
             resources: Some(LinuxResources {
                 devices: vec![LinuxDeviceCgroup {
                     access: "rwm".to_string().into(),
                     allow: false,
-                    typ: Default::default(),
-                    major: Default::default(),
-                    minor: Default::default(),
+                    ..Default::default()
                 }]
                 .into(),
-                memory: Default::default(),
-                cpu: Default::default(),
-                pids: Default::default(),
-                block_io: Default::default(),
-                hugepage_limits: Default::default(),
-                network: Default::default(),
-                rdma: Default::default(),
-                unified: Default::default(),
+                ..Default::default()
             }),
-            // Defaults to None
-            cgroups_path: Default::default(),
             namespaces: get_default_namespaces().into(),
-            // Empty Vec
-            devices: Default::default(),
-            // Empty String
-            rootfs_propagation: Default::default(),
             masked_paths: get_default_maskedpaths().into(),
             readonly_paths: get_default_readonly_paths().into(),
-            // Empty String
-            mount_label: Default::default(),
-            seccomp: None,
-            intel_rdt: None,
-            personality: None,
+            ..Default::default()
         }
     }
 }

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -94,10 +94,6 @@ impl Default for Process {
         Process {
             // Don't create an interactive terminal for container by default
             terminal: false.into(),
-            // Gives default console size of 0, 0
-            console_size: Default::default(),
-            // Gives process a uid and gid of 0 (root)
-            user: Default::default(),
             // By default executes sh command, giving user shell
             args: vec!["sh".to_string()].into(),
             // Sets linux default enviroment for binaries and default xterm emulator
@@ -110,22 +106,13 @@ impl Default for Process {
             cwd: "/".into(),
             // By default does not allow process to gain additional privileges
             no_new_privileges: true.into(),
-            // Empty String, no default apparmor
-            apparmor_profile: Default::default(),
-            // Empty String, no default selinux
-            selinux_label: Default::default(),
-            // See impl Default for LinuxCapabilities
-            capabilities: Some(Default::default()),
-            // Sets the default maximum of 1024 files the process can open
-            // This is the same as the linux kernel default
             rlimits: vec![LinuxRlimit {
                 typ: LinuxRlimitType::RlimitNofile,
                 hard: 1024,
                 soft: 1024,
             }]
             .into(),
-            oom_score_adj: None,
-            command_line: None,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
This reduces the noise and fixes some wrong comments about the default
types.