### PR TITLE
Fix visible supporting code

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,7 @@ let image_manifest = ImageManifestBuilder::default()
     .layers(layers)
     .build()
     .expect("build image manifest");
-```
 
-- Write image manifest to file
-```rust no_run
-# use oci_spec::image::ImageManifest;
-# let image_manifest = ImageManifest::from_file("manifest.json").unwrap();
 image_manifest.to_file_pretty("my-manifest.json").unwrap();
 ```
 


### PR DESCRIPTION
Github markdown does not support the rustdoc extension, so supporting code was visible in the readme on github.