### PR TITLE
Publish  LinuxPids attribute

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -363,6 +363,7 @@ pub struct LinuxCpu {
 /// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3).
 pub struct LinuxPids {
     #[serde(default)]
+    #[getset(get = "pub")]
     /// Maximum number of PIDs. Default is "no limit".
     limit: i64,
 }

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -352,7 +352,9 @@ pub struct LinuxCpu {
     mems: Option<String>,
 }
 
-#[derive(Builder, Clone, Copy, Debug, Default, Deserialize, Eq, Getters, PartialEq, Serialize)]
+#[derive(
+    Builder, Clone, Copy, Debug, Default, Deserialize, Eq, CopyGetters, PartialEq, Serialize,
+)]
 #[builder(
     default,
     pattern = "owned",
@@ -363,7 +365,6 @@ pub struct LinuxCpu {
 /// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3).
 pub struct LinuxPids {
     #[serde(default)]
-    #[getset(get = "pub")]
     /// Maximum number of PIDs. Default is "no limit".
     limit: i64,
 }


### PR DESCRIPTION
Hi, I tried to upgrade oci-spec-rs in youki.
I want to call LinuxPids::limit() function is not public.
I try to publish this function.

https://docs.rs/oci-spec/0.5.1/oci_spec/runtime/struct.LinuxPids.html

ref: https://github.com/containers/youki/pull/266
