### PR TITLE
Implement From<Spec> for SpecBuilder

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -227,6 +227,55 @@ impl Spec {
     }
 }
 
+impl From<Spec> for SpecBuilder {
+    fn from(spec: Spec) -> Self {
+        let mut spec_builder = SpecBuilder::default().version(spec.version());
+
+        spec_builder = match spec.root() {
+            Some(root) => spec_builder.root(root.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.mounts() {
+            Some(mounts) => spec_builder.mounts(mounts.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.process() {
+            Some(process) => spec_builder.process(process.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.hostname() {
+            Some(hostname) => spec_builder.hostname(hostname.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.hooks() {
+            Some(hooks) => spec_builder.hooks(hooks.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.annotations() {
+            Some(annotations) => spec_builder.annotations(annotations.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.linux() {
+            Some(linux) => spec_builder.linux(linux.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.solaris() {
+            Some(solaris) => spec_builder.solaris(solaris.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.windows() {
+            Some(windows) => spec_builder.windows(windows.clone()),
+            None => spec_builder,
+        };
+        spec_builder = match spec.vm() {
+            Some(vm) => spec_builder.vm(vm.clone()),
+            None => spec_builder,
+        };
+
+        spec_builder
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,6 +342,30 @@ mod tests {
         assert_eq!(
             spec, loaded_spec,
             "The saved spec is not the same as the loaded spec"
+        );
+    }
+
+    #[test]
+    fn test_modify_spec() {
+        let spec = Spec {
+            ..Default::default()
+        };
+
+        // We abuse clone here because we want to keep a record for later
+        // asserts. In real use, the spec and the new_root will be consumed by
+        // builder, as expected.
+        let default_root = spec.root().clone().unwrap();
+        let new_root = RootBuilder::default()
+            .path(Path::new("/this/is/not/a/good/path"))
+            .build()
+            .unwrap();
+        let spec_builder: SpecBuilder = SpecBuilder::from(spec).root(new_root.clone());
+        let new_spec = spec_builder.build().unwrap();
+
+        assert_eq!(new_root.path(), new_spec.root().as_ref().unwrap().path());
+        assert_ne!(
+            default_root.path(),
+            new_spec.root().as_ref().unwrap().path()
         );
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -244,7 +244,7 @@ impl From<Spec> for SpecBuilder {
             None => spec_builder,
         };
         spec_builder = match spec.hostname() {
-            Some(hostname) => spec_builder.hostname(hostname.clone()),
+            Some(hostname) => spec_builder.hostname(hostname),
             None => spec_builder,
         };
         spec_builder = match spec.hooks() {
@@ -347,9 +347,7 @@ mod tests {
 
     #[test]
     fn test_modify_spec() {
-        let spec = Spec {
-            ..Default::default()
-        };
+        let spec = Spec::default();
 
         // We abuse clone here because we want to keep a record for later
         // asserts. In real use, the spec and the new_root will be consumed by


### PR DESCRIPTION
We now have at least two situations we need to modify the spec. We made the tradeoff to have Spec as immutable. The missing piece is actually transfer Spec into SpecBuilder and consume the original Spec. Unfortunately, the derive-builder lib we use don't generate the From methods automatically, which I think they should. Otherwise, immutable structure becomes really hard to use. Most of the functional programming languages implement this transparently in the runtime with copy on write, but here we have to do this ourselves. There is an PR (https://github.com/colin-kiegel/rust-derive-builder/pull/215) in the derive-builder lib, but looks like it's not merging anytime soon based on the conversation. So for the moment, let's implement this and any other struct in the spec that we need to modify.

Fix https://github.com/containers/youki/issues/351.