### PR TITLE
derive setters for spec and mount

### DIFF
--- a/src/runtime/miscellaneous.rs
+++ b/src/runtime/miscellaneous.rs
@@ -1,6 +1,6 @@
 use crate::error::OciSpecError;
 use derive_builder::Builder;
-use getset::{CopyGetters, Getters};
+use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -37,14 +37,16 @@ impl Default for Root {
     }
 }
 
-#[derive(Builder, Clone, Debug, Default, Deserialize, Eq, Getters, PartialEq, Serialize)]
+#[derive(
+    Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
+)]
 #[builder(
     default,
     pattern = "owned",
     setter(into, strip_option),
     build_fn(error = "OciSpecError")
 )]
-#[getset(get = "pub")]
+#[getset(get = "pub", set = "pub")]
 /// Mount specifies a mount for a container.
 pub struct Mount {
     /// Destination is the absolute path where the mount will be placed in

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,7 +1,7 @@
 //! [OCI runtime spec](https://github.com/opencontainers/runtime-spec) types and definitions.
 
 use derive_builder::Builder;
-use getset::Getters;
+use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -34,14 +34,14 @@ pub use vm::*;
 pub use windows::*;
 
 /// Base configuration for the container.
-#[derive(Builder, Clone, Debug, Deserialize, Getters, PartialEq, Serialize)]
+#[derive(Builder, Clone, Debug, Deserialize, Getters, Setters, PartialEq, Serialize)]
 #[builder(
     default,
     pattern = "owned",
     setter(into, strip_option),
     build_fn(error = "OciSpecError")
 )]
-#[getset(get = "pub")]
+#[getset(get = "pub", set = "pub")]
 pub struct Spec {
     #[serde(default, rename = "ociVersion")]
     ///  MUST be in SemVer v2.0.0 format and specifies the version of the


### PR DESCRIPTION
As discussed in #74, this will greatly reduce the need to copy spec/mount when modifying these structures. Leaving the rest as is at the moment. Hopefully, this is enough.