### PR TITLE
Add tests to load an actual spec

### DIFF
--- a/src/runtime/hooks.rs
+++ b/src/runtime/hooks.rs
@@ -3,7 +3,6 @@ use derive_builder::Builder;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::time::Duration;
 
 #[derive(Builder, Clone, Debug, Default, Deserialize, Eq, Getters, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -99,6 +98,7 @@ pub struct Hook {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[getset(get_copy = "pub")]
-    /// Timeout is the duration before aborting the hook.
-    timeout: Option<Duration>,
+    /// Timeout is the number of seconds before aborting the hook. If set,
+    /// timeout MUST be greater than zero.
+    timeout: Option<i64>,
 }

--- a/src/runtime/test.rs
+++ b/src/runtime/test.rs
@@ -29,3 +29,10 @@ fn test_linux_device_cgroup_to_string() {
         .expect("build device cgroup");
     assert_eq!(ldc.to_string(), "a 1:9 rwm");
 }
+
+#[test]
+fn test_load_sample_spec() {
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/runtime/test/fixture/sample.json");
+    Spec::load(fixture_path).unwrap();
+}

--- a/src/runtime/test.rs
+++ b/src/runtime/test.rs
@@ -34,5 +34,6 @@ fn test_linux_device_cgroup_to_string() {
 fn test_load_sample_spec() {
     let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src/runtime/test/fixture/sample.json");
-    Spec::load(fixture_path).unwrap();
+    let err = Spec::load(fixture_path);
+    assert!(err.is_ok(), "failed to load spec: {:?}", err);
 }

--- a/src/runtime/test/fixture/sample.json
+++ b/src/runtime/test/fixture/sample.json
@@ -1,0 +1,407 @@
+{
+    "ociVersion": "0.5.0-dev",
+    "process": {
+        "terminal": true,
+        "user": {
+            "uid": 1,
+            "gid": 1,
+            "additionalGids": [
+                5,
+                6
+            ]
+        },
+        "args": [
+            "sh"
+        ],
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "TERM=xterm"
+        ],
+        "cwd": "/",
+        "capabilities": {
+            "bounding": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL",
+                "CAP_NET_BIND_SERVICE"
+            ],
+            "permitted": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL",
+                "CAP_NET_BIND_SERVICE"
+            ],
+            "inheritable": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL",
+                "CAP_NET_BIND_SERVICE"
+            ],
+            "effective": [
+                "CAP_AUDIT_WRITE",
+                "CAP_KILL"
+            ],
+            "ambient": [
+                "CAP_NET_BIND_SERVICE"
+            ]
+        },
+        "rlimits": [
+            {
+                "type": "RLIMIT_CORE",
+                "hard": 1024,
+                "soft": 1024
+            },
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            }
+        ],
+        "apparmorProfile": "acme_secure_profile",
+        "selinuxLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675",
+        "noNewPrivileges": true
+    },
+    "root": {
+        "path": "rootfs",
+        "readonly": true
+    },
+    "hostname": "slartibartfast",
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc"
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/mqueue",
+            "type": "mqueue",
+            "source": "mqueue",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys/fs/cgroup",
+            "type": "cgroup",
+            "source": "cgroup",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "relatime",
+                "ro"
+            ]
+        }
+    ],
+    "hooks": {
+        "prestart": [
+            {
+                "path": "/usr/bin/fix-mounts",
+                "args": [
+                    "fix-mounts",
+                    "arg1",
+                    "arg2"
+                ],
+                "env": [
+                    "key1=value1"
+                ]
+            },
+            {
+                "path": "/usr/bin/setup-network"
+            }
+        ],
+        "createRuntime": [
+            {
+                "path": "/usr/bin/fix-mounts",
+                "args": [
+                    "fix-mounts",
+                    "arg1",
+                    "arg2"
+                ],
+                "env": [
+                    "key1=value1"
+                ]
+            },
+            {
+                "path": "/usr/bin/setup-network"
+            }
+        ],
+        "createContainer": [
+            {
+                "path": "/usr/bin/mount-hook",
+                "args": [
+                    "-mount",
+                    "arg1",
+                    "arg2"
+                ],
+                "env": [
+                    "key1=value1"
+                ]
+            }
+        ],
+        "startContainer": [
+            {
+                "path": "/usr/bin/refresh-ldcache"
+            }
+        ],
+        "poststart": [
+            {
+                "path": "/usr/bin/notify-start",
+                "timeout": 5
+            }
+        ],
+        "poststop": [
+            {
+                "path": "/usr/sbin/cleanup.sh",
+                "args": [
+                    "cleanup.sh",
+                    "-f"
+                ]
+            }
+        ]
+    },
+    "linux": {
+        "devices": [
+            {
+                "path": "/dev/fuse",
+                "type": "c",
+                "major": 10,
+                "minor": 229,
+                "fileMode": 438,
+                "uid": 0,
+                "gid": 0
+            },
+            {
+                "path": "/dev/sda",
+                "type": "b",
+                "major": 8,
+                "minor": 0,
+                "fileMode": 432,
+                "uid": 0,
+                "gid": 0
+            }
+        ],
+        "uidMappings": [
+            {
+                "containerID": 0,
+                "hostID": 1000,
+                "size": 32000
+            }
+        ],
+        "gidMappings": [
+            {
+                "containerID": 0,
+                "hostID": 1000,
+                "size": 32000
+            }
+        ],
+        "sysctl": {
+            "net.ipv4.ip_forward": "1",
+            "net.core.somaxconn": "256"
+        },
+        "cgroupsPath": "/myRuntime/myContainer",
+        "resources": {
+            "network": {
+                "classID": 1048577,
+                "priorities": [
+                    {
+                        "name": "eth0",
+                        "priority": 500
+                    },
+                    {
+                        "name": "eth1",
+                        "priority": 1000
+                    }
+                ]
+            },
+            "pids": {
+                "limit": 32771
+            },
+            "hugepageLimits": [
+                {
+                    "pageSize": "2MB",
+                    "limit": 9223372036854772000
+                },
+                {
+                    "pageSize": "64KB",
+                    "limit": 1000000
+                }
+            ],
+            "oomScoreAdj": 100,
+            "memory": {
+                "limit": 536870912,
+                "reservation": 536870912,
+                "swap": 536870912,
+                "kernel": -1,
+                "kernelTCP": -1,
+                "swappiness": 0,
+                "disableOOMKiller": false,
+                "useHierarchy": false
+            },
+            "cpu": {
+                "shares": 1024,
+                "quota": 1000000,
+                "period": 500000,
+                "realtimeRuntime": 950000,
+                "realtimePeriod": 1000000,
+                "cpus": "2-3",
+                "mems": "0-7"
+            },
+            "devices": [
+                {
+                    "allow": false,
+                    "access": "rwm"
+                },
+                {
+                    "allow": true,
+                    "type": "c",
+                    "major": 10,
+                    "minor": 229,
+                    "access": "rw"
+                },
+                {
+                    "allow": true,
+                    "type": "b",
+                    "major": 8,
+                    "minor": 0,
+                    "access": "r"
+                }
+            ],
+            "blockIO": {
+                "weight": 10,
+                "leafWeight": 10,
+                "weightDevice": [
+                    {
+                        "major": 8,
+                        "minor": 0,
+                        "weight": 500,
+                        "leafWeight": 300
+                    },
+                    {
+                        "major": 8,
+                        "minor": 16,
+                        "weight": 500
+                    }
+                ],
+                "throttleReadBpsDevice": [
+                    {
+                        "major": 8,
+                        "minor": 0,
+                        "rate": 600
+                    }
+                ],
+                "throttleWriteIOPSDevice": [
+                    {
+                        "major": 8,
+                        "minor": 16,
+                        "rate": 300
+                    }
+                ]
+            }
+        },
+        "rootfsPropagation": "slave",
+        "seccomp": {
+            "defaultAction": "SCMP_ACT_ALLOW",
+            "architectures": [
+                "SCMP_ARCH_X86",
+                "SCMP_ARCH_X32"
+            ],
+            "syscalls": [
+                {
+                    "names": [
+                        "getcwd",
+                        "chmod"
+                    ],
+                    "action": "SCMP_ACT_ERRNO"
+                }
+            ]
+        },
+        "namespaces": [
+            {
+                "type": "pid"
+            },
+            {
+                "type": "network"
+            },
+            {
+                "type": "ipc"
+            },
+            {
+                "type": "uts"
+            },
+            {
+                "type": "mount"
+            },
+            {
+                "type": "user"
+            },
+            {
+                "type": "cgroup"
+            }
+        ],
+        "maskedPaths": [
+            "/proc/kcore",
+            "/proc/latency_stats",
+            "/proc/timer_stats",
+            "/proc/sched_debug"
+        ],
+        "readonlyPaths": [
+            "/proc/asound",
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+        ],
+        "mountLabel": "system_u:object_r:svirt_sandbox_file_t:s0:c715,c811"
+    },
+    "annotations": {
+        "com.example.key1": "value1",
+        "com.example.key2": "value2"
+    }
+}


### PR DESCRIPTION
1. Without using an actual spec, we only tested spec generated by our code. If we mess up with the types, we will fail to notice it. The `sample.json` taken directly from `opencontainer/runtime-spec.
2. Hook timeout should not be Duration. Duration implies a much richer structure. Here, the timeout means number of seconds, represented by an i64 integer. We can't parse that to a Duration without custom parser.