### PR TITLE
Add mutable accessors for some important Vec/HashMap fields

### DIFF
--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -4,7 +4,7 @@ use crate::{
     from_file, from_reader, to_file, to_writer,
 };
 use derive_builder::Builder;
-use getset::{Getters, Setters};
+use getset::{Getters, MutGetters, Setters};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(test)]
 use std::collections::BTreeMap;
@@ -14,7 +14,9 @@ use std::{
     path::Path,
 };
 
-#[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize)]
+#[derive(
+    Builder, Clone, Debug, Deserialize, Eq, Getters, MutGetters, Setters, PartialEq, Serialize,
+)]
 #[builder(
     default,
     pattern = "owned",
@@ -73,9 +75,11 @@ pub struct ImageConfiguration {
     /// The rootfs key references the layer content addresses used by the
     /// image. This makes the image config hash depend on the
     /// filesystem hash.
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
     rootfs: RootFs,
     /// Describes the history of each layer. The array is ordered from first
     /// to last.
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
     history: Vec<History>,
 }
 
@@ -195,7 +199,17 @@ impl Default for ImageConfiguration {
 }
 
 #[derive(
-    Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
+    Builder,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Getters,
+    MutGetters,
+    Setters,
+    PartialEq,
+    Serialize,
 )]
 #[serde(rename_all = "PascalCase")]
 #[builder(
@@ -268,6 +282,7 @@ pub struct Config {
     /// The field contains arbitrary metadata for the container.
     /// This property MUST use the annotation rules.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
     labels: Option<HashMap<String, String>>,
     /// The field contains the system call signal that will be
     /// sent to the container to exit. The signal can be a signal
@@ -331,7 +346,9 @@ where
     }
 }
 
-#[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize)]
+#[derive(
+    Builder, Clone, Debug, Deserialize, Eq, Getters, MutGetters, Setters, PartialEq, Serialize,
+)]
 #[builder(
     default,
     pattern = "owned",
@@ -346,6 +363,7 @@ pub struct RootFs {
     typ: String,
     /// An array of layer content hashes (DiffIDs), in order
     /// from first to last.
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
     diff_ids: Vec<String>,
 }
 

--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -4,7 +4,7 @@ use crate::{
     from_file, from_reader, to_file, to_writer,
 };
 use derive_builder::Builder;
-use getset::{CopyGetters, Getters, Setters};
+use getset::{CopyGetters, Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -13,7 +13,17 @@ use std::{
 };
 
 #[derive(
-    Builder, Clone, CopyGetters, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
+    Builder,
+    Clone,
+    CopyGetters,
+    Debug,
+    Deserialize,
+    Eq,
+    Getters,
+    MutGetters,
+    Setters,
+    PartialEq,
+    Serialize,
 )]
 #[serde(rename_all = "camelCase")]
 #[builder(
@@ -57,13 +67,13 @@ pub struct ImageManifest {
     /// The final filesystem layout MUST match the result of applying
     /// the layers to an empty directory. The ownership, mode, and other
     /// attributes of the initial empty directory are unspecified.
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
     layers: Vec<Descriptor>,
     /// This OPTIONAL property contains arbitrary metadata for the image
     /// manifest. This OPTIONAL property MUST use the annotation
     /// rules.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
     #[builder(default)]
     annotations: Option<HashMap<String, String>>,
 }
@@ -233,6 +243,15 @@ mod tests {
 
         // assert
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn getset() {
+        let mut manifest = create_manifest();
+        assert_eq!(manifest.layers().len(), 3);
+        let layer_copy = manifest.layers()[0].clone();
+        manifest.layers_mut().push(layer_copy);
+        assert_eq!(manifest.layers().len(), 4);
     }
 
     #[test]


### PR DESCRIPTION
Part of https://github.com/containers/oci-spec-rs/issues/86

An obvious operation to support is generating a derived container
image.  Here we want to take some existing data such as the image
manifest and configuration, and append to key fields such as
the image layers, the config diffids and the history.

Another common operation is adding/changing labels.

Having to create a deep-copy of all this data is unfortunate.
I am not very concerned about performance here, but it's also
an ergonomic hit.

Obviously giving raw `&mut` access to fields means that it goes
"behind the back" of the derive builder, and if we ever started
trying to use more advanced things like validation, that wouldn't
work.

Honestly, I am increasingly convinced the builder thing
is just not worth it and it'd be better to have plain structs with
`pub` fields.  But for now, let's allow direct mutation.