### PR TITLE
Use buffered I/O for JSON by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use error::*;
 
 fn from_file<P: AsRef<Path>, T: DeserializeOwned>(path: P) -> Result<T> {
     let path = path.as_ref();
-    let manifest_file = fs::File::open(path)?;
-    let manifest = serde_json::from_reader(&manifest_file)?;
+    let manifest_file = std::io::BufReader::new(fs::File::open(path)?);
+    let manifest = serde_json::from_reader(manifest_file)?;
     Ok(manifest)
 }
 
@@ -38,6 +38,7 @@ fn to_file<P: AsRef<Path>, T: Serialize>(item: &T, path: P, pretty: bool) -> Res
         .create(true)
         .truncate(true)
         .open(path)?;
+    let file = std::io::BufWriter::new(file);
 
     match pretty {
         true => serde_json::to_writer_pretty(file, item)?,


### PR DESCRIPTION
This is a *gigantic* performance trap in Rust.  Before:

```
$ cargo test --no-run  # To ensure we've built
$ strace -f -e read cargo test --package oci-spec --lib -- image::config::tests::load_configuration_from_file --exact --nocapture &| wc -l
1870
```

After:

```
$ cargo test --no-run
$ strace -f -e read cargo test --package oci-spec --lib -- image::config::tests::load_configuration_from_file --exact --nocapture &| wc -l
638
```

And specifically in the child process before, one can see stuff like this:

```
[pid 456480] read(3, "\"", 1)           = 1
[pid 456480] read(3, "e", 1)            = 1
[pid 456480] read(3, "m", 1)            = 1
[pid 456480] read(3, "p", 1)            = 1
[pid 456480] read(3, "t", 1)            = 1
[pid 456480] read(3, "y", 1)            = 1
[pid 456480] read(3, "_", 1)            = 1
[pid 456480] read(3, "l", 1)            = 1
[pid 456480] read(3, "a", 1)            = 1
[pid 456480] read(3, "y", 1)            = 1
[pid 456480] read(3, "e", 1)            = 1
[pid 456480] read(3, "r", 1)            = 1
[pid 456480] read(3, "\"", 1)           = 1
[pid 456480] read(3, ":", 1)            = 1
[pid 456480] read(3, " ", 1)            = 1
```

In a post-Spectre world, system calls are more expensive.  Making
*single byte* reads is about the worst thing one can do.