### PR TITLE
`impl Default` for `Os` and `Arch`, use in `ImageConfiguration::default()`

### DIFF
--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -15,7 +15,17 @@ use std::{
 };
 
 #[derive(
-    Builder, Clone, Debug, Deserialize, Eq, Getters, MutGetters, Setters, PartialEq, Serialize,
+    Builder,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Getters,
+    MutGetters,
+    Setters,
+    PartialEq,
+    Serialize,
 )]
 #[builder(
     default,
@@ -178,23 +188,6 @@ impl ImageConfiguration {
     /// ```
     pub fn to_writer_pretty<W: Write>(&self, writer: &mut W) -> Result<()> {
         to_writer(&self, writer, true)
-    }
-}
-
-impl Default for ImageConfiguration {
-    fn default() -> Self {
-        Self {
-            created: Default::default(),
-            author: Default::default(),
-            architecture: Default::default(),
-            os: Default::default(),
-            os_version: Default::default(),
-            os_features: Default::default(),
-            variant: Default::default(),
-            config: Default::default(),
-            rootfs: Default::default(),
-            history: Default::default(),
-        }
     }
 }
 

--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -186,8 +186,8 @@ impl Default for ImageConfiguration {
         Self {
             created: Default::default(),
             author: Default::default(),
-            architecture: Arch::Amd64,
-            os: Os::Linux,
+            architecture: Default::default(),
+            os: Default::default(),
             os_version: Default::default(),
             os_features: Default::default(),
             variant: Default::default(),

--- a/src/image/descriptor.rs
+++ b/src/image/descriptor.rs
@@ -112,8 +112,8 @@ pub struct Platform {
 impl Default for Platform {
     fn default() -> Self {
         Self {
-            architecture: Arch::Amd64,
-            os: Os::Linux,
+            architecture: Default::default(),
+            os: Default::default(),
             os_version: Default::default(),
             os_features: Default::default(),
             variant: Default::default(),

--- a/src/image/descriptor.rs
+++ b/src/image/descriptor.rs
@@ -62,7 +62,9 @@ pub struct Descriptor {
     platform: Option<Platform>,
 }
 
-#[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize)]
+#[derive(
+    Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
+)]
 #[builder(
     pattern = "owned",
     setter(into, strip_option),
@@ -107,18 +109,6 @@ pub struct Platform {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     variant: Option<String>,
-}
-
-impl Default for Platform {
-    fn default() -> Self {
-        Self {
-            architecture: Default::default(),
-            os: Default::default(),
-            os_version: Default::default(),
-            os_features: Default::default(),
-            variant: Default::default(),
-        }
-    }
 }
 
 impl Descriptor {

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -227,6 +227,12 @@ impl<'de> Deserialize<'de> for Os {
     }
 }
 
+impl Default for Os {
+    fn default() -> Self {
+        Os::from(std::env::consts::OS)
+    }
+}
+
 /// Name of the CPU target architecture.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Arch {
@@ -368,5 +374,18 @@ impl<'de> Deserialize<'de> for Arch {
     {
         let arch = String::deserialize(deserializer)?;
         Ok(arch.as_str().into())
+    }
+}
+
+impl Default for Arch {
+    fn default() -> Self {
+        // Translate from the Rust architecture names to the Go versions.
+        // I think the Rust ones are the same as the Linux kernel ones.
+        let goarch = match std::env::consts::ARCH {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            o => o,
+        };
+        Arch::from(goarch)
     }
 }


### PR DESCRIPTION


Hardcoding Linux/x86_64 is a trap because it will silently do the
right thing only for users on that platform.

Closes: https://github.com/containers/oci-spec-rs/issues/88