### PR TITLE
Add docs about how to cut a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ oci-spec = "0.5.4"
 ```
 *Compiler support: requires rustc 1.54+*
 
+If you want to propose or cut a new release, then please follow our 
+[release process documentation](./release.md).
+
 ## Image Format Spec Examples
 - Load image manifest from filesystem
 ```rust no_run
@@ -123,8 +126,7 @@ let list = RepositoryListBuilder::default()
             .repositories(vec!["busybox".to_owned()])
             .build().unwrap();
 ```
+
 # Contributing
 This project welcomes your PRs and issues. Should you wish to work on an issue, please claim it first by commenting on the 
 issue that you want to work on it. This is to prevent duplicated efforts from contributers on the same issue.
-
-

--- a/release.md
+++ b/release.md
@@ -1,0 +1,15 @@
+# Releasing a new version of oci-spec-rs
+
+A new release of this crate can be proposed by running the version bump script:
+
+```console
+./hack/release x.y.z
+```
+
+Push the changes to your fork and draft a new GitHub Pull Request (PR) which
+should now contain 2 commits, one which bumps the release version and another
+one to turn it _back to dev_.
+
+If the PR got merged, then create a new tag pointing to the first commit of that
+PR (named _Bump to x.y.z_). The changelog can be created by using GitHub's
+release note creation feature via the user interface.


### PR DESCRIPTION
We now outline our lightweight release process to correctly bump the version numbers.
