### PR TITLE
Implement `ToString` for `ImageIndex`, `ImageManifest`, and `ImageConfiguration`

### DIFF
--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -221,6 +221,17 @@ impl ImageConfiguration {
     }
 }
 
+/// Implement `ToString` directly since we cannot avoid twice memory allocation
+/// when using auto-implementaion through `Display`.
+impl ToString for ImageConfiguration {
+    fn to_string(&self) -> String {
+        // Serde seralization never fails since this is
+        // a combination of String and enums.
+        self.to_string_pretty()
+            .expect("ImageConfiguration JSON convertion failed")
+    }
+}
+
 #[derive(
     Builder,
     Clone,

--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -1,7 +1,7 @@
 use super::{Arch, Os};
 use crate::{
     error::{OciSpecError, Result},
-    from_file, from_reader, to_file, to_writer,
+    from_file, from_reader, to_file, to_string, to_writer,
 };
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
@@ -188,6 +188,36 @@ impl ImageConfiguration {
     /// ```
     pub fn to_writer_pretty<W: Write>(&self, writer: &mut W) -> Result<()> {
         to_writer(&self, writer, true)
+    }
+
+    /// Attempts to write an image configuration to a string as JSON.
+    /// # Errors
+    /// This function will return an [OciSpecError::SerDe](crate::OciSpecError::SerDe) if
+    /// the image configuration cannot be serialized.
+    /// # Example
+    /// ``` no_run
+    /// use oci_spec::image::ImageConfiguration;
+    ///
+    /// let image_configuration = ImageConfiguration::from_file("config.json").unwrap();
+    /// let json_str = image_configuration.to_string().unwrap();
+    /// ```
+    pub fn to_string(&self) -> Result<String> {
+        to_string(&self, false)
+    }
+
+    /// Attempts to write an image configuration to a string as pretty printed JSON.
+    /// # Errors
+    /// This function will return an [OciSpecError::SerDe](crate::OciSpecError::SerDe) if
+    /// the image configuration cannot be serialized.
+    /// # Example
+    /// ``` no_run
+    /// use oci_spec::image::ImageConfiguration;
+    ///
+    /// let image_configuration = ImageConfiguration::from_file("config.json").unwrap();
+    /// let json_str = image_configuration.to_string_pretty().unwrap();
+    /// ```
+    pub fn to_string_pretty(&self) -> Result<String> {
+        to_string(&self, true)
     }
 }
 
@@ -539,6 +569,19 @@ mod tests {
 
         // assert
         let expected = fs::read(get_config_path()).expect("read expected");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn save_config_to_string() {
+        // arrange
+        let config = create_config();
+
+        // act
+        let actual = config.to_string_pretty().expect("to string");
+
+        // assert
+        let expected = fs::read_to_string(get_config_path()).expect("read expected");
         assert_eq!(actual, expected);
     }
 }

--- a/src/image/index.rs
+++ b/src/image/index.rs
@@ -195,6 +195,17 @@ impl Default for ImageIndex {
     }
 }
 
+/// Implement `ToString` directly since we cannot avoid twice memory allocation
+/// when using auto-implementaion through `Display`.
+impl ToString for ImageIndex {
+    fn to_string(&self) -> String {
+        // Serde seralization never fails since this is
+        // a combination of String and enums.
+        self.to_string_pretty()
+            .expect("ImageIndex to JSON convertion failed")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{fs, path::PathBuf};

--- a/src/image/index.rs
+++ b/src/image/index.rs
@@ -1,7 +1,7 @@
 use super::{Descriptor, MediaType};
 use crate::{
     error::{OciSpecError, Result},
-    from_file, from_reader, to_file, to_writer,
+    from_file, from_reader, to_file, to_string, to_writer,
 };
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, Setters};
@@ -152,6 +152,36 @@ impl ImageIndex {
     pub fn to_writer_pretty<W: Write>(&self, writer: &mut W) -> Result<()> {
         to_writer(&self, writer, true)
     }
+
+    /// Attempts to write an image index to a string as JSON.
+    /// # Errors
+    /// This function will return an [OciSpecError::SerDe](crate::OciSpecError::SerDe) if
+    /// the image configuration cannot be serialized.
+    /// # Example
+    /// ``` no_run
+    /// use oci_spec::image::ImageIndex;
+    ///
+    /// let image_index = ImageIndex::from_file("index.json").unwrap();
+    /// let json_str = image_index.to_string().unwrap();
+    /// ```
+    pub fn to_string(&self) -> Result<String> {
+        to_string(&self, false)
+    }
+
+    /// Attempts to write an image index to a string as pretty printed JSON.
+    /// # Errors
+    /// This function will return an [OciSpecError::SerDe](crate::OciSpecError::SerDe) if
+    /// the image configuration cannot be serialized.
+    /// # Example
+    /// ``` no_run
+    /// use oci_spec::image::ImageIndex;
+    ///
+    /// let image_index = ImageIndex::from_file("index.json").unwrap();
+    /// let json_str = image_index.to_string_pretty().unwrap();
+    /// ```
+    pub fn to_string_pretty(&self) -> Result<String> {
+        to_string(&self, true)
+    }
 }
 
 impl Default for ImageIndex {
@@ -271,6 +301,19 @@ mod tests {
 
         // assert
         let expected = fs::read(get_index_path()).expect("read expected");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn save_index_to_string() {
+        // arrange
+        let index = create_index();
+
+        // act
+        let actual = index.to_string_pretty().expect("to string");
+
+        // assert
+        let expected = fs::read_to_string(get_index_path()).expect("read expected");
         assert_eq!(actual, expected);
     }
 }

--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -1,7 +1,7 @@
 use super::{Descriptor, MediaType};
 use crate::{
     error::{OciSpecError, Result},
-    from_file, from_reader, to_file, to_writer,
+    from_file, from_reader, to_file, to_string, to_writer,
 };
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
@@ -174,6 +174,36 @@ impl ImageManifest {
     pub fn to_writer_pretty<W: Write>(&self, writer: &mut W) -> Result<()> {
         to_writer(&self, writer, true)
     }
+
+    /// Attempts to write an image manifest to a string as JSON.
+    /// # Errors
+    /// This function will return an [OciSpecError::SerDe](crate::OciSpecError::SerDe) if
+    /// the image configuration cannot be serialized.
+    /// # Example
+    /// ``` no_run
+    /// use oci_spec::image::ImageManifest;
+    ///
+    /// let image_manifest = ImageManifest::from_file("manifest.json").unwrap();
+    /// let json_str = image_manifest.to_string().unwrap();
+    /// ```
+    pub fn to_string(&self) -> Result<String> {
+        to_string(&self, false)
+    }
+
+    /// Attempts to write an image manifest to a string as pretty printed JSON.
+    /// # Errors
+    /// This function will return an [OciSpecError::SerDe](crate::OciSpecError::SerDe) if
+    /// the image configuration cannot be serialized.
+    /// # Example
+    /// ``` no_run
+    /// use oci_spec::image::ImageManifest;
+    ///
+    /// let image_manifest = ImageManifest::from_file("manifest.json").unwrap();
+    /// let json_str = image_manifest.to_string_pretty().unwrap();
+    /// ```
+    pub fn to_string_pretty(&self) -> Result<String> {
+        to_string(&self, true)
+    }
 }
 
 #[cfg(test)]
@@ -297,6 +327,19 @@ mod tests {
 
         // assert
         let expected = fs::read(get_manifest_path()).expect("read expected");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn save_manifest_to_string() {
+        // arrange
+        let manifest = create_manifest();
+
+        // act
+        let actual = manifest.to_string_pretty().expect("to string");
+
+        // assert
+        let expected = fs::read_to_string(get_manifest_path()).expect("read expected");
         assert_eq!(actual, expected);
     }
 }

--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -206,6 +206,17 @@ impl ImageManifest {
     }
 }
 
+/// Implement `ToString` directly since we cannot avoid twice memory allocation
+/// when using auto-implementaion through `Display`.
+impl ToString for ImageManifest {
+    fn to_string(&self) -> String {
+        // Serde seralization never fails since this is
+        // a combination of String and enums.
+        self.to_string_pretty()
+            .expect("ImageManifest to JSON convertion failed")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{fs, path::PathBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,3 +56,10 @@ fn to_writer<W: Write, T: Serialize>(item: &T, writer: &mut W, pretty: bool) -> 
 
     Ok(())
 }
+
+fn to_string<T: Serialize>(item: &T, pretty: bool) -> Result<String> {
+    Ok(match pretty {
+        true => serde_json::to_string_pretty(item)?,
+        false => serde_json::to_string(item)?,
+    })
+}


### PR DESCRIPTION
This PR adds

- `to_string` and `to_string_pretty` for three structs listed on title implementing `to_writer`
  - We can do same thing like
    ```rust
    let image_manifest = ImageManifest::from_file("manifest.json").unwrap();
    let mut out = String::new();
    image_manifest.to_writer(out.as_bytes_mut()).unwrap();
    ```
    but `to_string` is rather simple like `to_file` is.
- Implement [ToString](https://doc.rust-lang.org/std/string/trait.ToString.html) for them
  - Although implementing `Display` is preferred generally, we cannot avoid twice allocating memory when auto-implementing `ToString` through `Display`.