### PR TITLE
Add missing rename attribute to LinuxSyscall (fixes `clone3` problems)

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1141,6 +1141,7 @@ impl Default for LinuxSeccompOperator {
     PartialEq,
     Serialize,
 )]
+#[serde(rename_all = "camelCase")]
 #[builder(
     default,
     pattern = "owned",


### PR DESCRIPTION
`LinuxSyscall` was missing this rename attribute, so the `errnoRet` field was not being handled properly.

This might have gone unnoticed as the default moby seccomp profile has [only one non-default errnoRet value](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json#L676) for `clone3`, but unfortunately it causes a lot of issues when it's missing (https://github.com/moby/moby/pull/42681, https://stackoverflow.com/questions/71941032/why-i-cannot-run-apt-update-inside-a-fresh-ubuntu22-04)