### PR TITLE
Do not panic if windows.layerFolder is null

### DIFF
--- a/src/runtime/test.rs
+++ b/src/runtime/test.rs
@@ -37,3 +37,11 @@ fn test_load_sample_spec() {
     let err = Spec::load(fixture_path);
     assert!(err.is_ok(), "failed to load spec: {err:?}");
 }
+
+#[test]
+fn test_load_sample_windows_spec() {
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/runtime/test/fixture/sample_windows.json");
+    let err = Spec::load(fixture_path);
+    assert!(err.is_ok(), "failed to load spec: {err:?}");
+}

--- a/src/runtime/test/fixture/sample_windows.json
+++ b/src/runtime/test/fixture/sample_windows.json
@@ -1,0 +1,43 @@
+{
+    "ociVersion": "0.5.0-dev",
+    "process": {
+        "terminal": true,
+        "user": {
+            "uid": 1,
+            "gid": 1,
+            "username": "ContainerUser"
+        },
+        "args": [
+            "cmd"
+        ],
+        "env": [
+            "PATH=C:\\Windows\\system32;C:\\Windows;"
+        ],
+        "cwd": "C:\\"
+    },
+    "root": {
+        "path": ""
+    },
+    "hostname": "slartibartfast",
+    "mounts": [
+    ],
+    "hooks": {
+    },
+    "linux": {
+    },
+    "windows": {
+        "layerFolders": null,
+        "resources": {
+            "cpu": {
+                "shares": 2
+            }
+        },
+        "network": {
+            "networkNamespace": "1124faf5-e1d3-43fe-b758-8e99e5b7fa02"
+        }
+    },
+    "annotations": {
+        "com.example.key1": "value1",
+        "com.example.key2": "value2"
+    }
+}

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -27,10 +27,11 @@ use std::collections::HashMap;
 /// Windows defines the runtime configuration for Windows based containers,
 /// including Hyper-V containers.
 pub struct Windows {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
     /// LayerFolders contains a list of absolute paths to directories
     /// containing image layers.
-    layer_folders: Vec<String>,
+    layer_folders: Option<Vec<String>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]


### PR DESCRIPTION
If windows layerFolders in `null` string then loading of the runtime spec fails. This happens when containerd serializes `Windows{}` portion of the spec due to the way golang serializes lists. Although the runtime spec says this is a required field, containerd 1.6 and 1.7 do not fill this field resulting in a null value when serialized to disk. See https://github.com/opencontainers/runtime-spec/issues/1185 for discussion of this field in the runtime spec.

fixes #126 