### PR TITLE
Rename closId -> closID.

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1242,7 +1242,7 @@ pub fn get_default_readonly_paths() -> Vec<String> {
 /// features and flags enabling Intel RDT CMT and MBM features.
 /// Intel RDT features are available in Linux 4.14 and newer kernel versions.
 pub struct LinuxIntelRdt {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "closID")]
     /// The identity for RDT Class of Service.
     clos_id: Option<String>,
 


### PR DESCRIPTION
The spec defines the variable as `closID`. Without this patch the clos_id value is always None.