### PR TITLE
Rootless runtime::Spec generation

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -139,7 +139,7 @@ impl Default for Linux {
 
 impl Linux {
     /// Return rootless Linux configuration.
-    pub fn rootless() -> Self {
+    pub fn rootless(uid: u32, gid: u32) -> Self {
         let mut namespaces = get_default_namespaces();
         namespaces.retain(|ns| ns.typ != LinuxNamespaceType::Network);
         namespaces.push(LinuxNamespace {
@@ -150,12 +150,12 @@ impl Linux {
             resources: None,
             uid_mappings: Some(vec![LinuxIdMapping {
                 container_id: 0,
-                host_id: 1000,
+                host_id: uid,
                 size: 1,
             }]),
             gid_mappings: Some(vec![LinuxIdMapping {
                 container_id: 0,
-                host_id: 1000,
+                host_id: gid,
                 size: 1,
             }]),
             namespaces: Some(namespaces),

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -3,7 +3,7 @@ use crate::error::{oci_error, OciSpecError};
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom, path::PathBuf};
+use std::{collections::HashMap, convert::TryFrom, path::PathBuf, vec};
 
 #[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -137,6 +137,33 @@ impl Default for Linux {
     }
 }
 
+impl Linux {
+    /// Return rootless Linux configuration.
+    pub fn rootless() -> Self {
+        let mut namespaces = get_default_namespaces();
+        namespaces.retain(|ns| ns.typ != LinuxNamespaceType::Network);
+        namespaces.push(LinuxNamespace {
+            typ: LinuxNamespaceType::User,
+            ..Default::default()
+        });
+        Self {
+            resources: None,
+            uid_mappings: Some(vec![LinuxIdMapping {
+                container_id: 0,
+                host_id: 1000,
+                size: 1,
+            }]),
+            gid_mappings: Some(vec![LinuxIdMapping {
+                container_id: 0,
+                host_id: 1000,
+                size: 1,
+            }]),
+            namespaces: Some(namespaces),
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
@@ -231,15 +258,17 @@ pub struct LinuxDeviceCgroup {
     /// Allow or deny
     allow: bool,
 
-    #[serde(default, rename = "type")]
+    #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
     #[getset(get_copy = "pub", set = "pub")]
     /// Device type, block, char, etc.
     typ: Option<LinuxDeviceType>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[getset(get_copy = "pub", set = "pub")]
     /// Device's major number
     major: Option<i64>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[getset(get_copy = "pub", set = "pub")]
     /// Device's minor number
     minor: Option<i64>,
@@ -843,6 +872,10 @@ pub fn get_default_namespaces() -> Vec<LinuxNamespace> {
         },
         LinuxNamespace {
             typ: LinuxNamespaceType::Mount,
+            path: Default::default(),
+        },
+        LinuxNamespace {
+            typ: LinuxNamespaceType::Cgroup,
             path: Default::default(),
         },
     ]

--- a/src/runtime/miscellaneous.rs
+++ b/src/runtime/miscellaneous.rs
@@ -149,3 +149,27 @@ pub fn get_default_mounts() -> Vec<Mount> {
         },
     ]
 }
+
+/// utility function to generate default rootless config for mounts.
+pub fn get_rootless_mounts() -> Vec<Mount> {
+    let mut mounts = get_default_mounts();
+    mounts
+        .iter_mut()
+        .find(|m| m.destination.to_string_lossy().to_string() == "/dev/pts")
+        .map(|m| {
+            if let Some(opts) = &mut m.options {
+                opts.retain(|o| o != "gid=5")
+            }
+            m
+        });
+    mounts
+        .iter_mut()
+        .find(|m| m.destination.to_string_lossy().to_string() == "/sys")
+        .map(|m| {
+            m.typ = Some("none".to_string());
+            m.source = Some("/sys".into());
+            m.options.as_mut().map(|o| o.push("rbind".to_string()));
+            m
+        });
+    mounts
+}

--- a/src/runtime/miscellaneous.rs
+++ b/src/runtime/miscellaneous.rs
@@ -155,7 +155,7 @@ pub fn get_rootless_mounts() -> Vec<Mount> {
     let mut mounts = get_default_mounts();
     mounts
         .iter_mut()
-        .find(|m| m.destination.to_string_lossy().to_string() == "/dev/pts")
+        .find(|m| m.destination.to_string_lossy() == "/dev/pts")
         .map(|m| {
             if let Some(opts) = &mut m.options {
                 opts.retain(|o| o != "gid=5")
@@ -164,11 +164,13 @@ pub fn get_rootless_mounts() -> Vec<Mount> {
         });
     mounts
         .iter_mut()
-        .find(|m| m.destination.to_string_lossy().to_string() == "/sys")
+        .find(|m| m.destination.to_string_lossy() == "/sys")
         .map(|m| {
             m.typ = Some("none".to_string());
             m.source = Some("/sys".into());
-            m.options.as_mut().map(|o| o.push("rbind".to_string()));
+            if let Some(o) = m.options.as_mut() {
+                o.push("rbind".to_string())
+            }
             m
         });
     mounts

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -244,12 +244,12 @@ impl Spec {
     /// ``` no_run
     /// use oci_spec::runtime::Spec;
     ///
-    /// let spec = Spec::rootless();
+    /// let spec = Spec::rootless(1000, 1000);
     /// ```
-    pub fn rootless() -> Self {
+    pub fn rootless(uid: u32, gid: u32) -> Self {
         Self {
             mounts: get_rootless_mounts().into(),
-            linux: Some(Linux::rootless()),
+            linux: Some(Linux::rootless(uid, gid)),
             ..Default::default()
         }
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -336,4 +336,114 @@ mod tests {
             "The saved spec is not the same as the loaded spec"
         );
     }
+
+    #[test]
+    fn test_rootless() {
+        const UID: u32 = 1000;
+        const GID: u32 = 1000;
+
+        let spec = Spec::default();
+        let spec_rootless = Spec::rootless(UID, GID);
+        assert!(
+            spec != spec_rootless,
+            "default spec and rootless spec should be different"
+        );
+
+        // Check rootless linux object.
+        let linux = spec_rootless
+            .linux
+            .expect("linux object should not be empty");
+        let uid_mappings = linux
+            .uid_mappings()
+            .clone()
+            .expect("uid mappings should not be empty");
+        let gid_mappings = linux
+            .gid_mappings()
+            .clone()
+            .expect("gid mappings should not be empty");
+        let namespaces = linux
+            .namespaces()
+            .clone()
+            .expect("namespaces should not be empty");
+        assert_eq!(uid_mappings.len(), 1, "uid mappings length should be 1");
+        assert_eq!(
+            uid_mappings[0].host_id(),
+            UID,
+            "uid mapping host id should be as defined"
+        );
+        assert_eq!(gid_mappings.len(), 1, "gid mappings length should be 1");
+        assert_eq!(
+            gid_mappings[0].host_id(),
+            GID,
+            "gid mapping host id should be as defined"
+        );
+        assert!(
+            !namespaces
+                .iter()
+                .any(|ns| ns.typ() == LinuxNamespaceType::Network),
+            "rootless spec should not contain network namespace type"
+        );
+        assert!(
+            namespaces
+                .iter()
+                .any(|ns| ns.typ() == LinuxNamespaceType::User),
+            "rootless spec should contain user namespace type"
+        );
+        assert!(
+            linux.resources().is_none(),
+            "resources in rootless spec should be empty"
+        );
+
+        // Check rootless mounts.
+        let mounts = spec_rootless.mounts.expect("mounts should not be empty");
+        assert!(
+            !mounts.iter().any(|m| {
+                if m.destination().to_string_lossy() == "/dev/pts" {
+                    return m
+                        .options()
+                        .clone()
+                        .expect("options should not be empty")
+                        .iter()
+                        .any(|o| o == "gid=5");
+                } else {
+                    false
+                }
+            }),
+            "gid=5 in rootless should not be present"
+        );
+        let sys_mount = mounts
+            .iter()
+            .find(|m| m.destination().to_string_lossy() == "/sys")
+            .expect("sys mount should be present");
+        assert_eq!(
+            sys_mount.typ(),
+            &Some("none".to_string()),
+            "type should be changed in sys mount"
+        );
+        assert_eq!(
+            sys_mount
+                .source()
+                .clone()
+                .expect("source should not be empty in sys mount")
+                .to_string_lossy(),
+            "/sys",
+            "source should be changed in sys mount"
+        );
+        assert!(
+            sys_mount
+                .options()
+                .clone()
+                .expect("options should not be empty in sys mount")
+                .iter()
+                .any(|o| o == "rbind"),
+            "rbind option should be present in sys mount"
+        );
+
+        // Check that some other objects have same values.
+        assert!(spec.process == spec_rootless.process);
+        assert!(spec.root == spec_rootless.root);
+        assert!(spec.hooks == spec_rootless.hooks);
+        assert!(spec.uid_mappings == spec_rootless.uid_mappings);
+        assert!(spec.gid_mappings == spec_rootless.gid_mappings);
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -239,6 +239,21 @@ impl Spec {
         Ok(())
     }
 
+    /// Return default rootless spec.
+    /// # Example
+    /// ``` no_run
+    /// use oci_spec::runtime::Spec;
+    ///
+    /// let spec = Spec::rootless();
+    /// ```
+    pub fn rootless() -> Self {
+        Self {
+            mounts: get_rootless_mounts().into(),
+            linux: Some(Linux::rootless()),
+            ..Default::default()
+        }
+    }
+
     fn canonicalize_path<B, P>(bundle: B, path: P) -> Result<PathBuf>
     where
         B: AsRef<Path>,


### PR DESCRIPTION
According to `runc spec --rootless` I added possibility to generate rootless spec. 

Also, runc adds `cgroup` linux namespace to both specs, so I decided to add it too.

Closes #130 