### PR TITLE
Rename os_version to os.version

### DIFF
--- a/src/image/descriptor.rs
+++ b/src/image/descriptor.rs
@@ -86,7 +86,7 @@ pub struct Platform {
     /// manifests where os.version is not known to work with the host OS
     /// version. Valid values are implementation-defined. e.g.
     /// 10.0.14393.1066 on windows.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "os.version", skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     os_version: Option<String>,
     /// This OPTIONAL property specifies an array of strings, each

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -193,6 +193,8 @@ impl From<&str> for Os {
             "aix" => Os::AIX,
             "android" => Os::Android,
             "darwin" => Os::Darwin,
+            // std::env::consts::OS returns "macos" instead of darwin
+            "macos" => Os::Darwin,
             "dragonfly" => Os::DragonFlyBSD,
             "freebsd" => Os::FreeBSD,
             "hurd" => Os::Hurd,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -260,6 +260,7 @@ impl Spec {
         P: AsRef<Path>,
     {
         Ok(if path.as_ref().is_absolute() {
+            println!("Other: {}", path.as_ref().display());
             fs::canonicalize(path.as_ref())?
         } else {
             let canonical_bundle_path = fs::canonicalize(&bundle)?;
@@ -298,7 +299,7 @@ mod tests {
                 .expect("failed to canonicalize rootfs");
 
             assert_eq!(
-                &rootfs_absolute_path,
+                &rootfs_absolute_path.canonicalize().unwrap(),
                 spec.root.expect("no root in spec").path()
             );
         }
@@ -313,7 +314,7 @@ mod tests {
                 .expect("failed to canonicalize rootfs");
 
             assert_eq!(
-                &rootfs_absolute_path,
+                &rootfs_absolute_path.canonicalize().unwrap(),
                 spec.root.expect("no root in spec").path()
             );
         }


### PR DESCRIPTION
I believe this should be `os.version` like `ImageConfig`? 

For example this is what Github container repo returns:

```json
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:b09d1eb75170275f0e465ed97e90718e596aab4a2413ba7eedcfb9f13580aca6",
      "size": 2015,
      "platform": {
        "architecture": "amd64",
        "os": "darwin",
        "os.version": "macOS 13.3"
      },
```

Also the tests failed on MacOS. I fixed this by canonicalising the temporary directory as well:

```
thread 'runtime::tests::test_canonicalize_rootfs' panicked at 'assertion failed: `(left == right)`
  left: `"/var/folders/q1/c031nnz57ls4qm4dk3m3w74h0000gn/T/.tmpxAJ0q3/rootfs"`,
 right: `"/private/var/folders/q1/c031nnz57ls4qm4dk3m3w74h0000gn/T/.tmpxAJ0q3/rootfs"`', src/runtime/mod.rs:306:13
```

Unfortunately `std::env::consts::OS` returns `macos` instead of Darwin, so I added an extra arm to the match condition to handle this. This makes `Default` work properly on MacOS