### PR TITLE
Add the release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+*"]
+
+jobs:
+  publish:
+    name: Publish Packages
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Publish
+        run: cargo publish --no-verify


### PR DESCRIPTION
Fix https://github.com/containers/oci-spec-rs/issues/139

Test workflow: https://github.com/utam0k/oci-spec-rs/actions/runs/5599810738/jobs/10241284044
It should be failed because the access token didn't set