### PR TITLE
support oci image spec 110rc5

### DIFF
--- a/src/image/descriptor.rs
+++ b/src/image/descriptor.rs
@@ -60,6 +60,22 @@ pub struct Descriptor {
     #[getset(get = "pub", set = "pub")]
     #[builder(default)]
     platform: Option<Platform>,
+    /// This OPTIONAL property contains the type of an artifact when the descriptor points to an
+    /// artifact. This is the value of the config descriptor mediaType when the descriptor
+    /// references an image manifest. If defined, the value MUST comply with RFC 6838, including
+    /// the naming requirements in its section 4.2, and MAY be registered with IANA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", set = "pub")]
+    #[builder(default)]
+    artifact_type: Option<MediaType>,
+    /// This OPTIONAL property contains an embedded representation of the referenced content.
+    /// Values MUST conform to the Base 64 encoding, as defined in RFC 4648. The decoded data MUST
+    /// be identical to the referenced content and SHOULD be verified against the digest and size
+    /// fields by content consumers. See Embedded Content for when this is appropriate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", set = "pub")]
+    #[builder(default)]
+    data: Option<String>,
 }
 
 #[derive(
@@ -109,6 +125,10 @@ pub struct Platform {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     variant: Option<String>,
+    /// This property is RESERVED for future versions of the specification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    features: Option<Vec<String>>,
 }
 
 impl Descriptor {
@@ -121,6 +141,8 @@ impl Descriptor {
             urls: Default::default(),
             annotations: Default::default(),
             platform: Default::default(),
+            artifact_type: Default::default(),
+            data: Default::default(),
         }
     }
 }

--- a/src/image/index.rs
+++ b/src/image/index.rs
@@ -43,11 +43,24 @@ pub struct ImageIndex {
     #[getset(get = "pub", set = "pub")]
     #[builder(default)]
     media_type: Option<MediaType>,
+    /// This OPTIONAL property contains the type of an artifact when the manifest is used for an
+    /// artifact. If defined, the value MUST comply with RFC 6838, including the naming
+    /// requirements in its section 4.2, and MAY be registered with IANA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", set = "pub")]
+    #[builder(default)]
+    artifact_type: Option<MediaType>,
     /// This REQUIRED property contains a list of manifests for specific
     /// platforms. While this property MUST be present, the size of
     /// the array MAY be zero.
     #[getset(get = "pub", set = "pub")]
     manifests: Vec<Descriptor>,
+    /// This OPTIONAL property specifies a descriptor of another manifest. This value, used by the
+    /// referrers API, indicates a relationship to the specified manifest.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", set = "pub")]
+    #[builder(default)]
+    subject: Option<Descriptor>,
     /// This OPTIONAL property contains arbitrary metadata for the image
     /// index. This OPTIONAL property MUST use the annotation rules.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,6 +204,8 @@ impl Default for ImageIndex {
             media_type: Default::default(),
             manifests: Default::default(),
             annotations: Default::default(),
+            artifact_type: Default::default(),
+            subject: Default::default(),
         }
     }
 }

--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -50,6 +50,15 @@ pub struct ImageManifest {
     #[getset(get = "pub", set = "pub")]
     #[builder(default)]
     media_type: Option<MediaType>,
+    /// This OPTIONAL property contains the type of an artifact when the manifest is used for an
+    /// artifact. This MUST be set when config.mediaType is set to the empty value. If defined, the
+    /// value MUST comply with RFC 6838, including the naming requirements in its section 4.2, and
+    /// MAY be registered with IANA. Implementations storing or copying image manifests MUST NOT
+    /// error on encountering an artifactType that is unknown to the implementation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", set = "pub")]
+    #[builder(default)]
+    artifact_type: Option<MediaType>,
     /// This REQUIRED property references a configuration object for a
     /// container, by digest. Beyond the descriptor requirements,
     /// the value has the following additional restrictions:
@@ -69,6 +78,12 @@ pub struct ImageManifest {
     /// attributes of the initial empty directory are unspecified.
     #[getset(get_mut = "pub", get = "pub", set = "pub")]
     layers: Vec<Descriptor>,
+    /// This OPTIONAL property specifies a descriptor of another manifest. This value, used by the
+    /// referrers API, indicates a relationship to the specified manifest.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", set = "pub")]
+    #[builder(default)]
+    subject: Option<Descriptor>,
     /// This OPTIONAL property contains arbitrary metadata for the image
     /// manifest. This OPTIONAL property MUST use the annotation
     /// rules.

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -60,6 +60,11 @@ pub enum MediaType {
     /// MediaType ArtifactManifest specifies the media type used for content addressable
     /// artifacts to store them along side container images in a registry.
     ArtifactManifest,
+    /// MediaType EmptyJSON specifies a descriptor that has no content for the implementation. The
+    /// blob payload is the most minimal content that is still a valid JSON object: {} (size of 2).
+    /// The blob digest of {} is
+    /// sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a.
+    EmptyJSON,
     /// MediaType not specified by OCI image format.
     Other(String),
 }
@@ -87,6 +92,7 @@ impl Display for MediaType {
             ),
             Self::ImageConfig => write!(f, "application/vnd.oci.image.config.v1+json"),
             Self::ArtifactManifest => write!(f, "application/vnd.oci.artifact.manifest.v1+json"),
+            Self::EmptyJSON => write!(f, "application/vnd.oci.empty.v1+json"),
             Self::Other(media_type) => write!(f, "{media_type}"),
         }
     }
@@ -113,6 +119,7 @@ impl From<&str> for MediaType {
             }
             "application/vnd.oci.image.config.v1+json" => MediaType::ImageConfig,
             "application/vnd.oci.artifact.manifest.v1+json" => MediaType::ArtifactManifest,
+            "application/vnd.oci.empty.v1+json" => MediaType::EmptyJSON,
             media => MediaType::Other(media.to_owned()),
         }
     }


### PR DESCRIPTION
For more information about why this is necessary, see description of #144.

The TL;DR is that this brings the repo up to the current release candidate
state for the OCI Image Spec (v1.1.0-rc5).
