### PR TITLE
Add comment on LinuxHugepageLimit

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -586,6 +586,7 @@ pub struct LinuxBlockIo {
     build_fn(error = "OciSpecError")
 )]
 /// LinuxHugepageLimit structure corresponds to limiting kernel hugepages.
+/// Default to reservation limits if supported. Otherwise fallback to page fault limits.
 pub struct LinuxHugepageLimit {
     #[serde(default)]
     #[getset(get = "pub", set = "pub")]
@@ -595,7 +596,7 @@ pub struct LinuxHugepageLimit {
 
     #[serde(default)]
     #[getset(get_copy = "pub", set = "pub")]
-    /// Limit is the limit of "hugepagesize" hugetlb usage.
+    /// Limit is the limit of "hugepagesize" hugetlb reservations (if supported) or usage.
     limit: i64,
 }
 


### PR DESCRIPTION
Adds support for the rsvd hugetlb cgroup. Enables reservation time checks on huge paqe memory limits. More info: https://github.com/opencontainers/runtime-spec/pull/1116