### PR TITLE
Validate `execCPUAffinity` of the runtime process spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ derive_builder = "0.20.0"
 getset = "0.1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
-regex = "1.10.5"
-once_cell = "1.19.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ derive_builder = "0.20.0"
 getset = "0.1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
+regex = "1.10.5"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ getset = "0.1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
 regex = "1.10.5"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ derive_builder = "0.20.0"
 getset = "0.1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
+regex = "1.10.5"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 use strum_macros::{Display as StrumDisplay, EnumString};
+use once_cell::sync::Lazy;
 
 #[derive(
     Builder,
@@ -622,10 +623,12 @@ where
     Ok(value)
 }
 
-fn validate_cpu_affinity(s: &str) -> Result<(), String> {
-    let re = Regex::new(r"^(\d+(-\d+)?)(,\d+(-\d+)?)*$").map_err(|e| e.to_string())?;
+static CPU_AFFINITY_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^(\d+(-\d+)?)(,\d+(-\d+)?)*$").expect("Failed to create regex for execCPUAffinity")
+});
 
-    if !re.is_match(s) {
+fn validate_cpu_affinity(s: &str) -> Result<(), String> {
+    if !CPU_AFFINITY_REGEX.is_match(s) {
         return Err(format!("Invalid CPU affinity format: {}", s));
     }
 

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -5,8 +5,7 @@ use crate::{
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
 use regex::Regex;
-use serde::de;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 use strum_macros::{Display as StrumDisplay, EnumString};
 

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 use strum_macros::{Display as StrumDisplay, EnumString};
@@ -623,13 +621,31 @@ where
     Ok(value)
 }
 
-static EXEC_CPU_AFFINITY_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^(\d+(-\d+)?)(,\d+(-\d+)?)*$").expect("Failed to create regex for execCPUAffinity")
-});
-
 fn validate_cpu_affinity(s: &str) -> Result<(), String> {
-    if !EXEC_CPU_AFFINITY_REGEX.is_match(s) {
-        return Err(format!("Invalid execCPUAffinity format: {}", s));
+    let iter = s.split(',');
+
+    for part in iter {
+        let mut range_iter = part.split('-');
+        let start = range_iter
+            .next()
+            .ok_or_else(|| format!("Invalid execCPUAffinity format: {}", s))?;
+
+        // Check if the start is a valid number
+        if start.parse::<usize>().is_err() {
+            return Err(format!("Invalid execCPUAffinity format: {}", s));
+        }
+
+        // Check if there's a range and if the end is a valid number
+        if let Some(end) = range_iter.next() {
+            if end.parse::<usize>().is_err() {
+                return Err(format!("Invalid execCPUAffinity format: {}", s));
+            }
+        }
+
+        // Ensure there's no extra data after the end of a range
+        if range_iter.next().is_some() {
+            return Err(format!("Invalid execCPUAffinity format: {}", s));
+        }
     }
 
     Ok(())

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -766,6 +766,13 @@ mod tests {
             .build();
         let err = affinity.unwrap_err();
         assert_eq!(err.to_string(), "Invalid execCPUAffinity format: 0-3,i");
+
+        let affinity = ExecCPUAffinityBuilder::default()
+            .cpu_affinity_initial("-".to_string())
+            .cpu_affinity_final("4-6,8".to_string())
+            .build();
+        let err = affinity.unwrap_err();
+        assert_eq!(err.to_string(), "Invalid execCPUAffinity format: -");
     }
 
     #[test]
@@ -776,6 +783,13 @@ mod tests {
             .build();
         let err = affinity.unwrap_err();
         assert_eq!(err.to_string(), "Invalid execCPUAffinity format: 0-l1");
+
+        let affinity = ExecCPUAffinityBuilder::default()
+            .cpu_affinity_initial("0-3,7".to_string())
+            .cpu_affinity_final(",1,2".to_string())
+            .build();
+        let err = affinity.unwrap_err();
+        assert_eq!(err.to_string(), "Invalid execCPUAffinity format: ,1,2");
     }
 
     #[test]

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -4,11 +4,11 @@ use crate::{
 };
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 use strum_macros::{Display as StrumDisplay, EnumString};
-use once_cell::sync::Lazy;
 
 #[derive(
     Builder,

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -623,13 +623,13 @@ where
     Ok(value)
 }
 
-static CPU_AFFINITY_REGEX: Lazy<Regex> = Lazy::new(|| {
+static EXEC_CPU_AFFINITY_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(\d+(-\d+)?)(,\d+(-\d+)?)*$").expect("Failed to create regex for execCPUAffinity")
 });
 
 fn validate_cpu_affinity(s: &str) -> Result<(), String> {
-    if !CPU_AFFINITY_REGEX.is_match(s) {
-        return Err(format!("Invalid CPU affinity format: {}", s));
+    if !EXEC_CPU_AFFINITY_REGEX.is_match(s) {
+        return Err(format!("Invalid execCPUAffinity format: {}", s));
     }
 
     Ok(())
@@ -749,7 +749,7 @@ mod tests {
             .cpu_affinity_final("4-6,8".to_string())
             .build();
         let err = affinity.unwrap_err();
-        assert_eq!(err.to_string(), "Invalid CPU affinity format: 0-3,i");
+        assert_eq!(err.to_string(), "Invalid execCPUAffinity format: 0-3,i");
     }
 
     #[test]
@@ -759,7 +759,7 @@ mod tests {
             .cpu_affinity_final("0-l1".to_string())
             .build();
         let err = affinity.unwrap_err();
-        assert_eq!(err.to_string(), "Invalid CPU affinity format: 0-l1");
+        assert_eq!(err.to_string(), "Invalid execCPUAffinity format: 0-l1");
     }
 
     #[test]


### PR DESCRIPTION
`execCPUAffinity`, which was added in https://github.com/containers/oci-spec-rs/pull/174, expects a particular format.

Ref: https://github.com/opencontainers/runtime-spec/blob/701738418b9555d5213337a0991fd0ffd6c37808/config.md?plain=1#L343-L353