### PR TITLE
Specifying Dependencies with tilde requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ derive_builder = "0.20.0"
 getset = "0.1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
-regex = "1.10.5"
-once_cell = "1.19.0"
+regex = "~1.10.5"
+once_cell = "~1.19.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
Specify a minimal version for regex and once_cell with some ability to update and enhance compatibility for other projects which depends on these crates.

Fixes #190