### PR TITLE
Use `LazyLock` instead of `once_cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ getset = "0.1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
 regex = "~1.10.5"
-once_cell = "~1.19.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -4,10 +4,10 @@ use crate::{
 };
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use strum_macros::{Display as StrumDisplay, EnumString};
 
 #[derive(
@@ -623,7 +623,7 @@ where
     Ok(value)
 }
 
-static EXEC_CPU_AFFINITY_REGEX: Lazy<Regex> = Lazy::new(|| {
+static EXEC_CPU_AFFINITY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(\d+(-\d+)?)(,\d+(-\d+)?)*$").expect("Failed to create regex for execCPUAffinity")
 });
 


### PR DESCRIPTION
We should prefer to use std library instead of 3rd party one.
Ref: https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#whats-in-1800-stable