### PR TITLE
Fix invalid format of comments

### DIFF
--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -67,6 +67,7 @@ pub struct ImageManifest {
     /// config. Implementations MUST support at least the following
     /// media types:
     /// - application/vnd.oci.image.config.v1+json
+    ///
     /// Manifests concerned with portability SHOULD use one of the above
     /// media types.
     #[getset(get = "pub", set = "pub")]


### PR DESCRIPTION
Clippy complains about the missing indentation in the comments. The suggested indentation is inappropriate because the rest of the sentences should be on a new line, not part of the current item. I have added a new blank line before `Manifests concerned ...` to address this issue.

```
error: doc list item missing indentation
  --> src/image/manifest.rs:70:9
   |
70 |     /// Manifests concerned with portability SHOULD use one of the above
   |         ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
note: the lint level is defined here
  --> src/lib.rs:1:23
```