### PR TITLE
Bump to version 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oci-spec"
-version = "0.6.8"
+version = "0.7.0"
 edition = "2021"
 authors = [
     "Furisto",


### PR DESCRIPTION
Since at least https://github.com/containers/oci-spec-rs/commit/ad7b406a0dc627b6c4ec226c1b3163cd6083afc5 broke semver.