### PR TITLE
Enable `cargo audit`

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,24 @@
+name: Security audit
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  audit:
+    permissions:
+      checks: write # for rustsec/audit-check to create check
+      contents: read # for actions/checkout to fetch code
+      issues: write # for rustsec/audit-check to create issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95 # v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit defines two new GitHub Actions, both running `cargo audit`.

One runs the command on a daily basis, this is used to detect new advisory that impact the project.

The other, runs the `cargo audit` command on PR that affect `Cargo.toml` or `Cargo.lock`.

The GitHub Action will create new issues whenever a new vulnerability is found.
