### PR TITLE
manifest: Use `.parse()` over `from_str()` in a test

### DIFF
--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -253,10 +253,9 @@ mod tests {
             .media_type(MediaType::ImageConfig)
             .size(7023u64)
             .digest(
-                Sha256Digest::from_str(
-                    "b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7",
-                )
-                .unwrap(),
+                "b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+                    .parse::<Sha256Digest>()
+                    .unwrap(),
             )
             .build()
             .expect("build config descriptor");


### PR DESCRIPTION
According to https://users.rust-lang.org/t/is-there-actually-a-semantic-difference-between-fromstr-and-tryfrom-str/92765 the role of FromStr is to be used by `parse()`.
I can't decide if this actually looks better. But, we may as well ensure coverage of it in tests.