### PR TITLE
Fix GHA invoking cargo audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Generate lockfile
+        run: cargo generate-lockfile
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

The security audit GHA is failing

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

We recently got a major version update of the audit-check GHA.

This version invokes:

```console
cargo audit --json --file ./Cargo.lock
```

Which fails, because we don't have a `Cargo.lock` file.

This commit makes sure the `Cargo.lock` is present prior to invoking `cargo audit`.

#### Does this PR introduce a user-facing change?

```release-note
None
```